### PR TITLE
Bump Wasmtime to 24.0.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -216,7 +216,7 @@ checksum = "7f30e7476521f6f8af1a1c4c0b8cc94f0bee37d91763d0ca2665f299b6cd8aec"
 
 [[package]]
 name = "byte-array-literals"
-version = "23.0.0"
+version = "24.0.0"
 
 [[package]]
 name = "byteorder"
@@ -578,7 +578,7 @@ dependencies = [
 
 [[package]]
 name = "cranelift"
-version = "0.110.0"
+version = "0.111.0"
 dependencies = [
  "cranelift-codegen",
  "cranelift-frontend",
@@ -591,14 +591,14 @@ dependencies = [
 
 [[package]]
 name = "cranelift-bforest"
-version = "0.110.0"
+version = "0.111.0"
 dependencies = [
  "cranelift-entity",
 ]
 
 [[package]]
 name = "cranelift-bitset"
-version = "0.110.0"
+version = "0.111.0"
 dependencies = [
  "serde",
  "serde_derive",
@@ -606,7 +606,7 @@ dependencies = [
 
 [[package]]
 name = "cranelift-codegen"
-version = "0.110.0"
+version = "0.111.0"
 dependencies = [
  "anyhow",
  "bumpalo",
@@ -637,25 +637,25 @@ dependencies = [
 
 [[package]]
 name = "cranelift-codegen-meta"
-version = "0.110.0"
+version = "0.111.0"
 dependencies = [
  "cranelift-codegen-shared",
 ]
 
 [[package]]
 name = "cranelift-codegen-shared"
-version = "0.110.0"
+version = "0.111.0"
 
 [[package]]
 name = "cranelift-control"
-version = "0.110.0"
+version = "0.111.0"
 dependencies = [
  "arbitrary",
 ]
 
 [[package]]
 name = "cranelift-entity"
-version = "0.110.0"
+version = "0.111.0"
 dependencies = [
  "cranelift-bitset",
  "serde",
@@ -693,7 +693,7 @@ dependencies = [
 
 [[package]]
 name = "cranelift-frontend"
-version = "0.110.0"
+version = "0.111.0"
 dependencies = [
  "cranelift-codegen",
  "hashbrown 0.14.3",
@@ -717,7 +717,7 @@ dependencies = [
 
 [[package]]
 name = "cranelift-interpreter"
-version = "0.110.0"
+version = "0.111.0"
 dependencies = [
  "cranelift-codegen",
  "cranelift-entity",
@@ -731,7 +731,7 @@ dependencies = [
 
 [[package]]
 name = "cranelift-isle"
-version = "0.110.0"
+version = "0.111.0"
 dependencies = [
  "codespan-reporting",
  "log",
@@ -740,7 +740,7 @@ dependencies = [
 
 [[package]]
 name = "cranelift-jit"
-version = "0.110.0"
+version = "0.111.0"
 dependencies = [
  "anyhow",
  "cranelift",
@@ -761,7 +761,7 @@ dependencies = [
 
 [[package]]
 name = "cranelift-module"
-version = "0.110.0"
+version = "0.111.0"
 dependencies = [
  "anyhow",
  "cranelift-codegen",
@@ -773,7 +773,7 @@ dependencies = [
 
 [[package]]
 name = "cranelift-native"
-version = "0.110.0"
+version = "0.111.0"
 dependencies = [
  "cranelift-codegen",
  "libc",
@@ -782,7 +782,7 @@ dependencies = [
 
 [[package]]
 name = "cranelift-object"
-version = "0.110.0"
+version = "0.111.0"
 dependencies = [
  "anyhow",
  "cranelift-codegen",
@@ -797,7 +797,7 @@ dependencies = [
 
 [[package]]
 name = "cranelift-reader"
-version = "0.110.0"
+version = "0.111.0"
 dependencies = [
  "anyhow",
  "cranelift-codegen",
@@ -807,7 +807,7 @@ dependencies = [
 
 [[package]]
 name = "cranelift-serde"
-version = "0.110.0"
+version = "0.111.0"
 dependencies = [
  "clap",
  "cranelift-codegen",
@@ -851,7 +851,7 @@ dependencies = [
 
 [[package]]
 name = "cranelift-wasm"
-version = "0.110.0"
+version = "0.111.0"
 dependencies = [
  "cranelift-codegen",
  "cranelift-entity",
@@ -1066,7 +1066,7 @@ checksum = "ef1a6892d9eef45c8fa6b9e0086428a2cca8491aca8f787c534a3d6d0bcb3ced"
 
 [[package]]
 name = "embedding"
-version = "23.0.0"
+version = "24.0.0"
 dependencies = [
  "anyhow",
  "dlmalloc",
@@ -1868,7 +1868,7 @@ dependencies = [
 
 [[package]]
 name = "min-platform-host"
-version = "23.0.0"
+version = "24.0.0"
 dependencies = [
  "anyhow",
  "libloading",
@@ -3100,7 +3100,7 @@ checksum = "830b7e5d4d90034032940e4ace0d9a9a057e7a45cd94e6c007832e39edb82f6d"
 
 [[package]]
 name = "verify-component-adapter"
-version = "23.0.0"
+version = "24.0.0"
 dependencies = [
  "anyhow",
  "wasmparser 0.211.1",
@@ -3150,7 +3150,7 @@ checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
 name = "wasi-common"
-version = "23.0.0"
+version = "24.0.0"
 dependencies = [
  "anyhow",
  "bitflags 2.4.1",
@@ -3190,7 +3190,7 @@ dependencies = [
 
 [[package]]
 name = "wasi-preview1-component-adapter"
-version = "23.0.0"
+version = "24.0.0"
 dependencies = [
  "bitflags 2.4.1",
  "byte-array-literals",
@@ -3422,7 +3422,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime"
-version = "23.0.0"
+version = "24.0.0"
 dependencies = [
  "addr2line",
  "anyhow",
@@ -3482,14 +3482,14 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-asm-macros"
-version = "23.0.0"
+version = "24.0.0"
 dependencies = [
  "cfg-if",
 ]
 
 [[package]]
 name = "wasmtime-bench-api"
-version = "23.0.0"
+version = "24.0.0"
 dependencies = [
  "anyhow",
  "cap-std",
@@ -3505,14 +3505,14 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-c-api"
-version = "23.0.0"
+version = "24.0.0"
 dependencies = [
  "wasmtime-c-api-impl",
 ]
 
 [[package]]
 name = "wasmtime-c-api-impl"
-version = "23.0.0"
+version = "24.0.0"
 dependencies = [
  "anyhow",
  "cap-std",
@@ -3530,7 +3530,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-c-api-macros"
-version = "23.0.0"
+version = "24.0.0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3538,7 +3538,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-cache"
-version = "23.0.0"
+version = "24.0.0"
 dependencies = [
  "anyhow",
  "base64",
@@ -3560,7 +3560,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-cli"
-version = "23.0.0"
+version = "24.0.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3626,7 +3626,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-cli-flags"
-version = "23.0.0"
+version = "24.0.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -3639,7 +3639,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-component-macro"
-version = "23.0.0"
+version = "24.0.0"
 dependencies = [
  "anyhow",
  "component-macro-test-helpers",
@@ -3659,11 +3659,11 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-component-util"
-version = "23.0.0"
+version = "24.0.0"
 
 [[package]]
 name = "wasmtime-cranelift"
-version = "23.0.0"
+version = "24.0.0"
 dependencies = [
  "anyhow",
  "cfg-if",
@@ -3685,7 +3685,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-environ"
-version = "23.0.0"
+version = "24.0.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -3727,7 +3727,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-explorer"
-version = "23.0.0"
+version = "24.0.0"
 dependencies = [
  "anyhow",
  "capstone",
@@ -3742,7 +3742,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-fiber"
-version = "23.0.0"
+version = "24.0.0"
 dependencies = [
  "anyhow",
  "backtrace",
@@ -3812,7 +3812,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-jit-debug"
-version = "23.0.0"
+version = "24.0.0"
 dependencies = [
  "object 0.36.0",
  "once_cell",
@@ -3822,7 +3822,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-jit-icache-coherence"
-version = "23.0.0"
+version = "24.0.0"
 dependencies = [
  "anyhow",
  "cfg-if",
@@ -3832,7 +3832,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-slab"
-version = "23.0.0"
+version = "24.0.0"
 
 [[package]]
 name = "wasmtime-test-macros"
@@ -3846,7 +3846,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-types"
-version = "23.0.0"
+version = "24.0.0"
 dependencies = [
  "anyhow",
  "cranelift-entity",
@@ -3858,7 +3858,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-versioned-export-macros"
-version = "23.0.0"
+version = "24.0.0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3867,7 +3867,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-wasi"
-version = "23.0.0"
+version = "24.0.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3900,7 +3900,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-wasi-http"
-version = "23.0.0"
+version = "24.0.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3926,7 +3926,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-wasi-nn"
-version = "23.0.0"
+version = "24.0.0"
 dependencies = [
  "anyhow",
  "cap-std",
@@ -3945,7 +3945,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-wasi-threads"
-version = "23.0.0"
+version = "24.0.0"
 dependencies = [
  "anyhow",
  "log",
@@ -3956,7 +3956,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-wast"
-version = "23.0.0"
+version = "24.0.0"
 dependencies = [
  "anyhow",
  "log",
@@ -3966,7 +3966,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-winch"
-version = "23.0.0"
+version = "24.0.0"
 dependencies = [
  "anyhow",
  "cranelift-codegen",
@@ -3981,7 +3981,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-wit-bindgen"
-version = "23.0.0"
+version = "24.0.0"
 dependencies = [
  "anyhow",
  "heck 0.4.0",
@@ -3991,7 +3991,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-wmemcheck"
-version = "23.0.0"
+version = "24.0.0"
 
 [[package]]
 name = "wast"
@@ -4048,7 +4048,7 @@ dependencies = [
 
 [[package]]
 name = "wiggle"
-version = "23.0.0"
+version = "24.0.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4065,7 +4065,7 @@ dependencies = [
 
 [[package]]
 name = "wiggle-generate"
-version = "23.0.0"
+version = "24.0.0"
 dependencies = [
  "anyhow",
  "heck 0.4.0",
@@ -4078,7 +4078,7 @@ dependencies = [
 
 [[package]]
 name = "wiggle-macro"
-version = "23.0.0"
+version = "24.0.0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4133,7 +4133,7 @@ checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "winch-codegen"
-version = "0.21.0"
+version = "0.22.0"
 dependencies = [
  "anyhow",
  "cranelift-codegen",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -153,7 +153,7 @@ exclude = [
 ]
 
 [workspace.package]
-version = "23.0.0"
+version = "24.0.0"
 authors = ["The Wasmtime Project Developers"]
 edition = "2021"
 # Wasmtime's current policy is that this number can be no larger than the
@@ -176,57 +176,57 @@ all = 'allow'
 
 [workspace.dependencies]
 arbitrary = { version = "1.3.1" }
-wasmtime-wmemcheck = { path = "crates/wmemcheck", version = "=23.0.0" }
-wasmtime = { path = "crates/wasmtime", version = "23.0.0", default-features = false }
-wasmtime-c-api-macros = { path = "crates/c-api-macros", version = "=23.0.0" }
-wasmtime-cache = { path = "crates/cache", version = "=23.0.0" }
-wasmtime-cli-flags = { path = "crates/cli-flags", version = "=23.0.0" }
-wasmtime-cranelift = { path = "crates/cranelift", version = "=23.0.0" }
-wasmtime-winch = { path = "crates/winch", version = "=23.0.0" }
-wasmtime-environ = { path = "crates/environ", version = "=23.0.0" }
-wasmtime-explorer = { path = "crates/explorer", version = "=23.0.0" }
-wasmtime-fiber = { path = "crates/fiber", version = "=23.0.0" }
-wasmtime-types = { path = "crates/types", version = "23.0.0" }
-wasmtime-jit-debug = { path = "crates/jit-debug", version = "=23.0.0" }
-wasmtime-wast = { path = "crates/wast", version = "=23.0.0" }
-wasmtime-wasi = { path = "crates/wasi", version = "23.0.0", default-features = false }
-wasmtime-wasi-http = { path = "crates/wasi-http", version = "=23.0.0", default-features = false }
-wasmtime-wasi-nn = { path = "crates/wasi-nn", version = "23.0.0" }
-wasmtime-wasi-threads = { path = "crates/wasi-threads", version = "23.0.0" }
-wasmtime-component-util = { path = "crates/component-util", version = "=23.0.0" }
-wasmtime-component-macro = { path = "crates/component-macro", version = "=23.0.0" }
-wasmtime-asm-macros = { path = "crates/asm-macros", version = "=23.0.0" }
-wasmtime-versioned-export-macros = { path = "crates/versioned-export-macros", version = "=23.0.0" }
-wasmtime-slab = { path = "crates/slab", version = "=23.0.0" }
+wasmtime-wmemcheck = { path = "crates/wmemcheck", version = "=24.0.0" }
+wasmtime = { path = "crates/wasmtime", version = "24.0.0", default-features = false }
+wasmtime-c-api-macros = { path = "crates/c-api-macros", version = "=24.0.0" }
+wasmtime-cache = { path = "crates/cache", version = "=24.0.0" }
+wasmtime-cli-flags = { path = "crates/cli-flags", version = "=24.0.0" }
+wasmtime-cranelift = { path = "crates/cranelift", version = "=24.0.0" }
+wasmtime-winch = { path = "crates/winch", version = "=24.0.0" }
+wasmtime-environ = { path = "crates/environ", version = "=24.0.0" }
+wasmtime-explorer = { path = "crates/explorer", version = "=24.0.0" }
+wasmtime-fiber = { path = "crates/fiber", version = "=24.0.0" }
+wasmtime-types = { path = "crates/types", version = "24.0.0" }
+wasmtime-jit-debug = { path = "crates/jit-debug", version = "=24.0.0" }
+wasmtime-wast = { path = "crates/wast", version = "=24.0.0" }
+wasmtime-wasi = { path = "crates/wasi", version = "24.0.0", default-features = false }
+wasmtime-wasi-http = { path = "crates/wasi-http", version = "=24.0.0", default-features = false }
+wasmtime-wasi-nn = { path = "crates/wasi-nn", version = "24.0.0" }
+wasmtime-wasi-threads = { path = "crates/wasi-threads", version = "24.0.0" }
+wasmtime-component-util = { path = "crates/component-util", version = "=24.0.0" }
+wasmtime-component-macro = { path = "crates/component-macro", version = "=24.0.0" }
+wasmtime-asm-macros = { path = "crates/asm-macros", version = "=24.0.0" }
+wasmtime-versioned-export-macros = { path = "crates/versioned-export-macros", version = "=24.0.0" }
+wasmtime-slab = { path = "crates/slab", version = "=24.0.0" }
 component-test-util = { path = "crates/misc/component-test-util" }
 component-fuzz-util = { path = "crates/misc/component-fuzz-util" }
-wiggle = { path = "crates/wiggle", version = "=23.0.0", default-features = false }
-wiggle-macro = { path = "crates/wiggle/macro", version = "=23.0.0" }
-wiggle-generate = { path = "crates/wiggle/generate", version = "=23.0.0" }
-wasi-common = { path = "crates/wasi-common", version = "=23.0.0", default-features = false }
+wiggle = { path = "crates/wiggle", version = "=24.0.0", default-features = false }
+wiggle-macro = { path = "crates/wiggle/macro", version = "=24.0.0" }
+wiggle-generate = { path = "crates/wiggle/generate", version = "=24.0.0" }
+wasi-common = { path = "crates/wasi-common", version = "=24.0.0", default-features = false }
 wasmtime-fuzzing = { path = "crates/fuzzing" }
-wasmtime-jit-icache-coherence = { path = "crates/jit-icache-coherence", version = "=23.0.0" }
-wasmtime-wit-bindgen = { path = "crates/wit-bindgen", version = "=23.0.0" }
+wasmtime-jit-icache-coherence = { path = "crates/jit-icache-coherence", version = "=24.0.0" }
+wasmtime-wit-bindgen = { path = "crates/wit-bindgen", version = "=24.0.0" }
 test-programs-artifacts = { path = 'crates/test-programs/artifacts' }
 
-cranelift-wasm = { path = "cranelift/wasm", version = "0.110.0" }
-cranelift-codegen = { path = "cranelift/codegen", version = "0.110.0", default-features = false, features = ["std", "unwind", "trace-log"] }
-cranelift-frontend = { path = "cranelift/frontend", version = "0.110.0" }
-cranelift-entity = { path = "cranelift/entity", version = "0.110.0" }
-cranelift-native = { path = "cranelift/native", version = "0.110.0" }
-cranelift-module = { path = "cranelift/module", version = "0.110.0" }
-cranelift-interpreter = { path = "cranelift/interpreter", version = "0.110.0" }
-cranelift-reader = { path = "cranelift/reader", version = "0.110.0" }
+cranelift-wasm = { path = "cranelift/wasm", version = "0.111.0" }
+cranelift-codegen = { path = "cranelift/codegen", version = "0.111.0", default-features = false, features = ["std", "unwind", "trace-log"] }
+cranelift-frontend = { path = "cranelift/frontend", version = "0.111.0" }
+cranelift-entity = { path = "cranelift/entity", version = "0.111.0" }
+cranelift-native = { path = "cranelift/native", version = "0.111.0" }
+cranelift-module = { path = "cranelift/module", version = "0.111.0" }
+cranelift-interpreter = { path = "cranelift/interpreter", version = "0.111.0" }
+cranelift-reader = { path = "cranelift/reader", version = "0.111.0" }
 cranelift-filetests = { path = "cranelift/filetests" }
-cranelift-object = { path = "cranelift/object", version = "0.110.0" }
-cranelift-jit = { path = "cranelift/jit", version = "0.110.0" }
+cranelift-object = { path = "cranelift/object", version = "0.111.0" }
+cranelift-jit = { path = "cranelift/jit", version = "0.111.0" }
 cranelift-fuzzgen = { path = "cranelift/fuzzgen" }
-cranelift-bforest = { path = "cranelift/bforest", version = "0.110.0" }
-cranelift-bitset = { path = "cranelift/bitset", version = "0.110.0" }
-cranelift-control = { path = "cranelift/control", version = "0.110.0" }
-cranelift = { path = "cranelift/umbrella", version = "0.110.0" }
+cranelift-bforest = { path = "cranelift/bforest", version = "0.111.0" }
+cranelift-bitset = { path = "cranelift/bitset", version = "0.111.0" }
+cranelift-control = { path = "cranelift/control", version = "0.111.0" }
+cranelift = { path = "cranelift/umbrella", version = "0.111.0" }
 
-winch-codegen = { path = "winch/codegen", version = "=0.21.0" }
+winch-codegen = { path = "winch/codegen", version = "=0.22.0" }
 
 wasi-preview1-component-adapter = { path = "crates/wasi-preview1-component-adapter" }
 byte-array-literals = { path = "crates/wasi-preview1-component-adapter/byte-array-literals" }

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -1,4 +1,4 @@
-## 23.0.0
+## 24.0.0
 
 Unreleased.
 
@@ -12,6 +12,7 @@ Release notes for previous releases of Wasmtime can be found on the respective
 release branches of the Wasmtime repository.
 
 <!-- ARCHIVE_START -->
+* [23.0.x](https://github.com/juntyr/wasmtime/blob/release-23.0.0/RELEASES.md)
 * [22.0.x](https://github.com/bytecodealliance/wasmtime/blob/release-22.0.0/RELEASES.md)
 * [21.0.x](https://github.com/bytecodealliance/wasmtime/blob/release-21.0.0/RELEASES.md)
 * [20.0.x](https://github.com/bytecodealliance/wasmtime/blob/release-20.0.0/RELEASES.md)

--- a/cranelift/bforest/Cargo.toml
+++ b/cranelift/bforest/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["The Cranelift Project Developers"]
 name = "cranelift-bforest"
-version = "0.110.0"
+version = "0.111.0"
 description = "A forest of B+-trees"
 license = "Apache-2.0 WITH LLVM-exception"
 documentation = "https://docs.rs/cranelift-bforest"

--- a/cranelift/bitset/Cargo.toml
+++ b/cranelift/bitset/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["The Cranelift Project Developers"]
 name = "cranelift-bitset"
-version = "0.110.0"
+version = "0.111.0"
 description = "Various bitset stuff for use inside Cranelift"
 license = "Apache-2.0 WITH LLVM-exception"
 documentation = "https://docs.rs/cranelift-bitset"

--- a/cranelift/codegen/Cargo.toml
+++ b/cranelift/codegen/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["The Cranelift Project Developers"]
 name = "cranelift-codegen"
-version = "0.110.0"
+version = "0.111.0"
 description = "Low-level code generator library"
 license = "Apache-2.0 WITH LLVM-exception"
 documentation = "https://docs.rs/cranelift-codegen"
@@ -19,7 +19,7 @@ workspace = true
 anyhow = { workspace = true, optional = true, features = ['std'] }
 bumpalo = "3"
 capstone = { workspace = true, optional = true }
-cranelift-codegen-shared = { path = "./shared", version = "0.110.0" }
+cranelift-codegen-shared = { path = "./shared", version = "0.111.0" }
 cranelift-entity = { workspace = true }
 cranelift-bforest = { workspace = true }
 cranelift-bitset = { workspace = true }
@@ -47,8 +47,8 @@ similar = "2.1.0"
 env_logger = { workspace = true }
 
 [build-dependencies]
-cranelift-codegen-meta = { path = "meta", version = "0.110.0" }
-cranelift-isle = { path = "../isle/isle", version = "=0.110.0" }
+cranelift-codegen-meta = { path = "meta", version = "0.111.0" }
+cranelift-isle = { path = "../isle/isle", version = "=0.111.0" }
 
 [features]
 default = ["std", "unwind", "host-arch", "timing"]

--- a/cranelift/codegen/meta/Cargo.toml
+++ b/cranelift/codegen/meta/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "cranelift-codegen-meta"
 authors = ["The Cranelift Project Developers"]
-version = "0.110.0"
+version = "0.111.0"
 description = "Metaprogram for cranelift-codegen code generator library"
 license = "Apache-2.0 WITH LLVM-exception"
 repository = "https://github.com/bytecodealliance/wasmtime"
@@ -15,4 +15,4 @@ workspace = true
 rustdoc-args = [ "--document-private-items" ]
 
 [dependencies]
-cranelift-codegen-shared = { path = "../shared", version = "0.110.0" }
+cranelift-codegen-shared = { path = "../shared", version = "0.111.0" }

--- a/cranelift/codegen/shared/Cargo.toml
+++ b/cranelift/codegen/shared/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["The Cranelift Project Developers"]
 name = "cranelift-codegen-shared"
-version = "0.110.0"
+version = "0.111.0"
 description = "For code shared between cranelift-codegen-meta and cranelift-codegen"
 license = "Apache-2.0 WITH LLVM-exception"
 repository = "https://github.com/bytecodealliance/wasmtime"

--- a/cranelift/control/Cargo.toml
+++ b/cranelift/control/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["The Cranelift Project Developers"]
 name = "cranelift-control"
-version = "0.110.0"
+version = "0.111.0"
 description = "White-box fuzz testing framework"
 license = "Apache-2.0 WITH LLVM-exception"
 repository = "https://github.com/bytecodealliance/wasmtime"

--- a/cranelift/entity/Cargo.toml
+++ b/cranelift/entity/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["The Cranelift Project Developers"]
 name = "cranelift-entity"
-version = "0.110.0"
+version = "0.111.0"
 description = "Data structures using entity references as mapping keys"
 license = "Apache-2.0 WITH LLVM-exception"
 documentation = "https://docs.rs/cranelift-entity"

--- a/cranelift/frontend/Cargo.toml
+++ b/cranelift/frontend/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["The Cranelift Project Developers"]
 name = "cranelift-frontend"
-version = "0.110.0"
+version = "0.111.0"
 description = "Cranelift IR builder helper"
 license = "Apache-2.0 WITH LLVM-exception"
 documentation = "https://docs.rs/cranelift-frontend"

--- a/cranelift/interpreter/Cargo.toml
+++ b/cranelift/interpreter/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cranelift-interpreter"
-version = "0.110.0"
+version = "0.111.0"
 authors = ["The Cranelift Project Developers"]
 description = "Interpret Cranelift IR"
 repository = "https://github.com/bytecodealliance/wasmtime"

--- a/cranelift/isle/isle/Cargo.toml
+++ b/cranelift/isle/isle/Cargo.toml
@@ -6,7 +6,7 @@ license = "Apache-2.0 WITH LLVM-exception"
 name = "cranelift-isle"
 readme = "../README.md"
 repository = "https://github.com/bytecodealliance/wasmtime/tree/main/cranelift/isle"
-version = "0.110.0"
+version = "0.111.0"
 
 [lints]
 workspace = true

--- a/cranelift/jit/Cargo.toml
+++ b/cranelift/jit/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cranelift-jit"
-version = "0.110.0"
+version = "0.111.0"
 authors = ["The Cranelift Project Developers"]
 description = "A JIT library backed by Cranelift"
 repository = "https://github.com/bytecodealliance/wasmtime"

--- a/cranelift/module/Cargo.toml
+++ b/cranelift/module/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cranelift-module"
-version = "0.110.0"
+version = "0.111.0"
 authors = ["The Cranelift Project Developers"]
 description = "Support for linking functions and data with Cranelift"
 repository = "https://github.com/bytecodealliance/wasmtime"

--- a/cranelift/native/Cargo.toml
+++ b/cranelift/native/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cranelift-native"
-version = "0.110.0"
+version = "0.111.0"
 authors = ["The Cranelift Project Developers"]
 description = "Support for targeting the host with Cranelift"
 documentation = "https://docs.rs/cranelift-native"

--- a/cranelift/object/Cargo.toml
+++ b/cranelift/object/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cranelift-object"
-version = "0.110.0"
+version = "0.111.0"
 authors = ["The Cranelift Project Developers"]
 description = "Emit Cranelift output to native object files with `object`"
 repository = "https://github.com/bytecodealliance/wasmtime"

--- a/cranelift/reader/Cargo.toml
+++ b/cranelift/reader/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["The Cranelift Project Developers"]
 name = "cranelift-reader"
-version = "0.110.0"
+version = "0.111.0"
 description = "Cranelift textual IR reader"
 license = "Apache-2.0 WITH LLVM-exception"
 documentation = "https://docs.rs/cranelift-reader"

--- a/cranelift/serde/Cargo.toml
+++ b/cranelift/serde/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cranelift-serde"
-version = "0.110.0"
+version = "0.111.0"
 authors = ["The Cranelift Project Developers"]
 description = "Serializer/Deserializer for Cranelift IR"
 repository = "https://github.com/bytecodealliance/wasmtime"

--- a/cranelift/umbrella/Cargo.toml
+++ b/cranelift/umbrella/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["The Cranelift Project Developers"]
 name = "cranelift"
-version = "0.110.0"
+version = "0.111.0"
 description = "Umbrella for commonly-used cranelift crates"
 license = "Apache-2.0 WITH LLVM-exception"
 documentation = "https://docs.rs/cranelift"

--- a/cranelift/wasm/Cargo.toml
+++ b/cranelift/wasm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cranelift-wasm"
-version = "0.110.0"
+version = "0.111.0"
 authors = ["The Cranelift Project Developers"]
 description = "Translator from WebAssembly to Cranelift IR"
 documentation = "https://docs.rs/cranelift-wasm"

--- a/crates/c-api/include/wasmtime.h
+++ b/crates/c-api/include/wasmtime.h
@@ -206,11 +206,11 @@
 /**
  * \brief Wasmtime version string.
  */
-#define WASMTIME_VERSION "23.0.0"
+#define WASMTIME_VERSION "24.0.0"
 /**
  * \brief Wasmtime major version number.
  */
-#define WASMTIME_VERSION_MAJOR 23
+#define WASMTIME_VERSION_MAJOR 24
 /**
  * \brief Wasmtime minor version number.
  */

--- a/supply-chain/imports.lock
+++ b/supply-chain/imports.lock
@@ -17,6 +17,10 @@ audited_as = "0.107.1"
 version = "0.110.0"
 audited_as = "0.108.1"
 
+[[unpublished.cranelift]]
+version = "0.111.0"
+audited_as = "0.109.0"
+
 [[unpublished.cranelift-bforest]]
 version = "0.107.0"
 audited_as = "0.105.2"
@@ -32,6 +36,10 @@ audited_as = "0.107.1"
 [[unpublished.cranelift-bforest]]
 version = "0.110.0"
 audited_as = "0.108.1"
+
+[[unpublished.cranelift-bforest]]
+version = "0.111.0"
+audited_as = "0.109.0"
 
 [[unpublished.cranelift-codegen]]
 version = "0.107.0"
@@ -49,6 +57,10 @@ audited_as = "0.107.1"
 version = "0.110.0"
 audited_as = "0.108.1"
 
+[[unpublished.cranelift-codegen]]
+version = "0.111.0"
+audited_as = "0.109.0"
+
 [[unpublished.cranelift-codegen-meta]]
 version = "0.107.0"
 audited_as = "0.105.2"
@@ -64,6 +76,10 @@ audited_as = "0.107.1"
 [[unpublished.cranelift-codegen-meta]]
 version = "0.110.0"
 audited_as = "0.108.1"
+
+[[unpublished.cranelift-codegen-meta]]
+version = "0.111.0"
+audited_as = "0.109.0"
 
 [[unpublished.cranelift-codegen-shared]]
 version = "0.107.0"
@@ -81,6 +97,10 @@ audited_as = "0.107.1"
 version = "0.110.0"
 audited_as = "0.108.1"
 
+[[unpublished.cranelift-codegen-shared]]
+version = "0.111.0"
+audited_as = "0.109.0"
+
 [[unpublished.cranelift-control]]
 version = "0.107.0"
 audited_as = "0.105.2"
@@ -96,6 +116,10 @@ audited_as = "0.107.1"
 [[unpublished.cranelift-control]]
 version = "0.110.0"
 audited_as = "0.108.1"
+
+[[unpublished.cranelift-control]]
+version = "0.111.0"
+audited_as = "0.109.0"
 
 [[unpublished.cranelift-entity]]
 version = "0.107.0"
@@ -113,6 +137,10 @@ audited_as = "0.107.1"
 version = "0.110.0"
 audited_as = "0.108.1"
 
+[[unpublished.cranelift-entity]]
+version = "0.111.0"
+audited_as = "0.109.0"
+
 [[unpublished.cranelift-frontend]]
 version = "0.107.0"
 audited_as = "0.105.2"
@@ -128,6 +156,10 @@ audited_as = "0.107.1"
 [[unpublished.cranelift-frontend]]
 version = "0.110.0"
 audited_as = "0.108.1"
+
+[[unpublished.cranelift-frontend]]
+version = "0.111.0"
+audited_as = "0.109.0"
 
 [[unpublished.cranelift-interpreter]]
 version = "0.107.0"
@@ -145,6 +177,10 @@ audited_as = "0.107.1"
 version = "0.110.0"
 audited_as = "0.108.1"
 
+[[unpublished.cranelift-interpreter]]
+version = "0.111.0"
+audited_as = "0.109.0"
+
 [[unpublished.cranelift-isle]]
 version = "0.107.0"
 audited_as = "0.105.2"
@@ -160,6 +196,10 @@ audited_as = "0.107.1"
 [[unpublished.cranelift-isle]]
 version = "0.110.0"
 audited_as = "0.108.1"
+
+[[unpublished.cranelift-isle]]
+version = "0.111.0"
+audited_as = "0.109.0"
 
 [[unpublished.cranelift-jit]]
 version = "0.107.0"
@@ -177,6 +217,10 @@ audited_as = "0.107.1"
 version = "0.110.0"
 audited_as = "0.108.1"
 
+[[unpublished.cranelift-jit]]
+version = "0.111.0"
+audited_as = "0.109.0"
+
 [[unpublished.cranelift-module]]
 version = "0.107.0"
 audited_as = "0.105.2"
@@ -192,6 +236,10 @@ audited_as = "0.107.1"
 [[unpublished.cranelift-module]]
 version = "0.110.0"
 audited_as = "0.108.1"
+
+[[unpublished.cranelift-module]]
+version = "0.111.0"
+audited_as = "0.109.0"
 
 [[unpublished.cranelift-native]]
 version = "0.107.0"
@@ -209,6 +257,10 @@ audited_as = "0.107.1"
 version = "0.110.0"
 audited_as = "0.108.1"
 
+[[unpublished.cranelift-native]]
+version = "0.111.0"
+audited_as = "0.109.0"
+
 [[unpublished.cranelift-object]]
 version = "0.107.0"
 audited_as = "0.105.2"
@@ -224,6 +276,10 @@ audited_as = "0.107.1"
 [[unpublished.cranelift-object]]
 version = "0.110.0"
 audited_as = "0.108.1"
+
+[[unpublished.cranelift-object]]
+version = "0.111.0"
+audited_as = "0.109.0"
 
 [[unpublished.cranelift-reader]]
 version = "0.107.0"
@@ -241,6 +297,10 @@ audited_as = "0.107.1"
 version = "0.110.0"
 audited_as = "0.108.1"
 
+[[unpublished.cranelift-reader]]
+version = "0.111.0"
+audited_as = "0.109.0"
+
 [[unpublished.cranelift-serde]]
 version = "0.107.0"
 audited_as = "0.105.2"
@@ -257,6 +317,10 @@ audited_as = "0.107.1"
 version = "0.110.0"
 audited_as = "0.108.1"
 
+[[unpublished.cranelift-serde]]
+version = "0.111.0"
+audited_as = "0.109.0"
+
 [[unpublished.cranelift-wasm]]
 version = "0.107.0"
 audited_as = "0.105.2"
@@ -273,6 +337,10 @@ audited_as = "0.107.1"
 version = "0.110.0"
 audited_as = "0.108.1"
 
+[[unpublished.cranelift-wasm]]
+version = "0.111.0"
+audited_as = "0.109.0"
+
 [[unpublished.wasi-common]]
 version = "20.0.0"
 audited_as = "18.0.2"
@@ -288,6 +356,10 @@ audited_as = "20.0.1"
 [[unpublished.wasi-common]]
 version = "23.0.0"
 audited_as = "21.0.1"
+
+[[unpublished.wasi-common]]
+version = "24.0.0"
+audited_as = "22.0.0"
 
 [[unpublished.wasmtime]]
 version = "20.0.0"
@@ -305,6 +377,10 @@ audited_as = "20.0.1"
 version = "23.0.0"
 audited_as = "21.0.1"
 
+[[unpublished.wasmtime]]
+version = "24.0.0"
+audited_as = "22.0.0"
+
 [[unpublished.wasmtime-asm-macros]]
 version = "20.0.0"
 audited_as = "18.0.2"
@@ -320,6 +396,10 @@ audited_as = "20.0.1"
 [[unpublished.wasmtime-asm-macros]]
 version = "23.0.0"
 audited_as = "21.0.1"
+
+[[unpublished.wasmtime-asm-macros]]
+version = "24.0.0"
+audited_as = "22.0.0"
 
 [[unpublished.wasmtime-cache]]
 version = "20.0.0"
@@ -337,6 +417,10 @@ audited_as = "20.0.1"
 version = "23.0.0"
 audited_as = "21.0.1"
 
+[[unpublished.wasmtime-cache]]
+version = "24.0.0"
+audited_as = "22.0.0"
+
 [[unpublished.wasmtime-cli]]
 version = "20.0.0"
 audited_as = "18.0.2"
@@ -352,6 +436,10 @@ audited_as = "20.0.1"
 [[unpublished.wasmtime-cli]]
 version = "23.0.0"
 audited_as = "21.0.1"
+
+[[unpublished.wasmtime-cli]]
+version = "24.0.0"
+audited_as = "22.0.0"
 
 [[unpublished.wasmtime-cli-flags]]
 version = "20.0.0"
@@ -369,6 +457,10 @@ audited_as = "20.0.1"
 version = "23.0.0"
 audited_as = "21.0.1"
 
+[[unpublished.wasmtime-cli-flags]]
+version = "24.0.0"
+audited_as = "22.0.0"
+
 [[unpublished.wasmtime-component-macro]]
 version = "20.0.0"
 audited_as = "18.0.2"
@@ -385,6 +477,10 @@ audited_as = "20.0.1"
 version = "23.0.0"
 audited_as = "21.0.1"
 
+[[unpublished.wasmtime-component-macro]]
+version = "24.0.0"
+audited_as = "22.0.0"
+
 [[unpublished.wasmtime-component-util]]
 version = "20.0.0"
 audited_as = "18.0.2"
@@ -401,6 +497,10 @@ audited_as = "20.0.1"
 version = "23.0.0"
 audited_as = "21.0.1"
 
+[[unpublished.wasmtime-component-util]]
+version = "24.0.0"
+audited_as = "22.0.0"
+
 [[unpublished.wasmtime-cranelift]]
 version = "20.0.0"
 audited_as = "18.0.2"
@@ -416,6 +516,10 @@ audited_as = "20.0.1"
 [[unpublished.wasmtime-cranelift]]
 version = "23.0.0"
 audited_as = "21.0.1"
+
+[[unpublished.wasmtime-cranelift]]
+version = "24.0.0"
+audited_as = "22.0.0"
 
 [[unpublished.wasmtime-cranelift-shared]]
 version = "20.0.0"
@@ -437,6 +541,10 @@ audited_as = "20.0.1"
 version = "23.0.0"
 audited_as = "21.0.1"
 
+[[unpublished.wasmtime-environ]]
+version = "24.0.0"
+audited_as = "22.0.0"
+
 [[unpublished.wasmtime-explorer]]
 version = "20.0.0"
 audited_as = "18.0.2"
@@ -452,6 +560,10 @@ audited_as = "20.0.1"
 [[unpublished.wasmtime-explorer]]
 version = "23.0.0"
 audited_as = "21.0.1"
+
+[[unpublished.wasmtime-explorer]]
+version = "24.0.0"
+audited_as = "22.0.0"
 
 [[unpublished.wasmtime-fiber]]
 version = "20.0.0"
@@ -469,6 +581,10 @@ audited_as = "20.0.1"
 version = "23.0.0"
 audited_as = "21.0.1"
 
+[[unpublished.wasmtime-fiber]]
+version = "24.0.0"
+audited_as = "22.0.0"
+
 [[unpublished.wasmtime-jit-debug]]
 version = "20.0.0"
 audited_as = "18.0.2"
@@ -485,6 +601,10 @@ audited_as = "20.0.1"
 version = "23.0.0"
 audited_as = "21.0.1"
 
+[[unpublished.wasmtime-jit-debug]]
+version = "24.0.0"
+audited_as = "22.0.0"
+
 [[unpublished.wasmtime-jit-icache-coherence]]
 version = "20.0.0"
 audited_as = "18.0.2"
@@ -500,6 +620,10 @@ audited_as = "20.0.1"
 [[unpublished.wasmtime-jit-icache-coherence]]
 version = "23.0.0"
 audited_as = "21.0.1"
+
+[[unpublished.wasmtime-jit-icache-coherence]]
+version = "24.0.0"
+audited_as = "22.0.0"
 
 [[unpublished.wasmtime-runtime]]
 version = "20.0.0"
@@ -525,6 +649,10 @@ audited_as = "20.0.1"
 version = "23.0.0"
 audited_as = "21.0.1"
 
+[[unpublished.wasmtime-slab]]
+version = "24.0.0"
+audited_as = "22.0.0"
+
 [[unpublished.wasmtime-types]]
 version = "20.0.0"
 audited_as = "18.0.2"
@@ -540,6 +668,10 @@ audited_as = "20.0.1"
 [[unpublished.wasmtime-types]]
 version = "23.0.0"
 audited_as = "21.0.1"
+
+[[unpublished.wasmtime-types]]
+version = "24.0.0"
+audited_as = "22.0.0"
 
 [[unpublished.wasmtime-wasi]]
 version = "20.0.0"
@@ -557,6 +689,10 @@ audited_as = "20.0.1"
 version = "23.0.0"
 audited_as = "21.0.1"
 
+[[unpublished.wasmtime-wasi]]
+version = "24.0.0"
+audited_as = "22.0.0"
+
 [[unpublished.wasmtime-wasi-http]]
 version = "20.0.0"
 audited_as = "18.0.2"
@@ -572,6 +708,10 @@ audited_as = "20.0.1"
 [[unpublished.wasmtime-wasi-http]]
 version = "23.0.0"
 audited_as = "21.0.1"
+
+[[unpublished.wasmtime-wasi-http]]
+version = "24.0.0"
+audited_as = "22.0.0"
 
 [[unpublished.wasmtime-wasi-nn]]
 version = "20.0.0"
@@ -589,6 +729,10 @@ audited_as = "20.0.1"
 version = "23.0.0"
 audited_as = "21.0.1"
 
+[[unpublished.wasmtime-wasi-nn]]
+version = "24.0.0"
+audited_as = "22.0.0"
+
 [[unpublished.wasmtime-wasi-threads]]
 version = "20.0.0"
 audited_as = "18.0.2"
@@ -604,6 +748,10 @@ audited_as = "20.0.1"
 [[unpublished.wasmtime-wasi-threads]]
 version = "23.0.0"
 audited_as = "21.0.1"
+
+[[unpublished.wasmtime-wasi-threads]]
+version = "24.0.0"
+audited_as = "22.0.0"
 
 [[unpublished.wasmtime-wast]]
 version = "20.0.0"
@@ -621,6 +769,10 @@ audited_as = "20.0.1"
 version = "23.0.0"
 audited_as = "21.0.1"
 
+[[unpublished.wasmtime-wast]]
+version = "24.0.0"
+audited_as = "22.0.0"
+
 [[unpublished.wasmtime-winch]]
 version = "20.0.0"
 audited_as = "18.0.2"
@@ -636,6 +788,10 @@ audited_as = "20.0.1"
 [[unpublished.wasmtime-winch]]
 version = "23.0.0"
 audited_as = "21.0.1"
+
+[[unpublished.wasmtime-winch]]
+version = "24.0.0"
+audited_as = "22.0.0"
 
 [[unpublished.wasmtime-wit-bindgen]]
 version = "20.0.0"
@@ -653,6 +809,10 @@ audited_as = "20.0.1"
 version = "23.0.0"
 audited_as = "21.0.1"
 
+[[unpublished.wasmtime-wit-bindgen]]
+version = "24.0.0"
+audited_as = "22.0.0"
+
 [[unpublished.wasmtime-wmemcheck]]
 version = "20.0.0"
 audited_as = "18.0.2"
@@ -668,6 +828,10 @@ audited_as = "20.0.1"
 [[unpublished.wasmtime-wmemcheck]]
 version = "23.0.0"
 audited_as = "21.0.1"
+
+[[unpublished.wasmtime-wmemcheck]]
+version = "24.0.0"
+audited_as = "22.0.0"
 
 [[unpublished.wiggle]]
 version = "20.0.0"
@@ -685,6 +849,10 @@ audited_as = "20.0.1"
 version = "23.0.0"
 audited_as = "21.0.1"
 
+[[unpublished.wiggle]]
+version = "24.0.0"
+audited_as = "22.0.0"
+
 [[unpublished.wiggle-generate]]
 version = "20.0.0"
 audited_as = "18.0.2"
@@ -701,6 +869,10 @@ audited_as = "20.0.1"
 version = "23.0.0"
 audited_as = "21.0.1"
 
+[[unpublished.wiggle-generate]]
+version = "24.0.0"
+audited_as = "22.0.0"
+
 [[unpublished.wiggle-macro]]
 version = "20.0.0"
 audited_as = "18.0.2"
@@ -716,6 +888,10 @@ audited_as = "20.0.1"
 [[unpublished.wiggle-macro]]
 version = "23.0.0"
 audited_as = "21.0.1"
+
+[[unpublished.wiggle-macro]]
+version = "24.0.0"
+audited_as = "22.0.0"
 
 [[unpublished.wiggle-test]]
 version = "0.0.0"
@@ -736,6 +912,10 @@ audited_as = "0.18.1"
 [[unpublished.winch-codegen]]
 version = "0.21.0"
 audited_as = "0.19.1"
+
+[[unpublished.winch-codegen]]
+version = "0.22.0"
+audited_as = "0.20.0"
 
 [[publisher.aho-corasick]]
 version = "1.0.2"
@@ -936,6 +1116,12 @@ when = "2024-05-22"
 user-id = 73222
 user-login = "wasmtime-publish"
 
+[[publisher.cranelift]]
+version = "0.109.0"
+when = "2024-06-20"
+user-id = 73222
+user-login = "wasmtime-publish"
+
 [[publisher.cranelift-bforest]]
 version = "0.105.2"
 when = "2024-02-28"
@@ -957,6 +1143,12 @@ user-login = "wasmtime-publish"
 [[publisher.cranelift-bforest]]
 version = "0.108.1"
 when = "2024-05-22"
+user-id = 73222
+user-login = "wasmtime-publish"
+
+[[publisher.cranelift-bforest]]
+version = "0.109.0"
+when = "2024-06-20"
 user-id = 73222
 user-login = "wasmtime-publish"
 
@@ -984,6 +1176,12 @@ when = "2024-05-22"
 user-id = 73222
 user-login = "wasmtime-publish"
 
+[[publisher.cranelift-codegen]]
+version = "0.109.0"
+when = "2024-06-20"
+user-id = 73222
+user-login = "wasmtime-publish"
+
 [[publisher.cranelift-codegen-meta]]
 version = "0.105.2"
 when = "2024-02-28"
@@ -1005,6 +1203,12 @@ user-login = "wasmtime-publish"
 [[publisher.cranelift-codegen-meta]]
 version = "0.108.1"
 when = "2024-05-22"
+user-id = 73222
+user-login = "wasmtime-publish"
+
+[[publisher.cranelift-codegen-meta]]
+version = "0.109.0"
+when = "2024-06-20"
 user-id = 73222
 user-login = "wasmtime-publish"
 
@@ -1032,6 +1236,12 @@ when = "2024-05-22"
 user-id = 73222
 user-login = "wasmtime-publish"
 
+[[publisher.cranelift-codegen-shared]]
+version = "0.109.0"
+when = "2024-06-20"
+user-id = 73222
+user-login = "wasmtime-publish"
+
 [[publisher.cranelift-control]]
 version = "0.105.2"
 when = "2024-02-28"
@@ -1053,6 +1263,12 @@ user-login = "wasmtime-publish"
 [[publisher.cranelift-control]]
 version = "0.108.1"
 when = "2024-05-22"
+user-id = 73222
+user-login = "wasmtime-publish"
+
+[[publisher.cranelift-control]]
+version = "0.109.0"
+when = "2024-06-20"
 user-id = 73222
 user-login = "wasmtime-publish"
 
@@ -1080,6 +1296,12 @@ when = "2024-05-22"
 user-id = 73222
 user-login = "wasmtime-publish"
 
+[[publisher.cranelift-entity]]
+version = "0.109.0"
+when = "2024-06-20"
+user-id = 73222
+user-login = "wasmtime-publish"
+
 [[publisher.cranelift-frontend]]
 version = "0.105.2"
 when = "2024-02-28"
@@ -1101,6 +1323,12 @@ user-login = "wasmtime-publish"
 [[publisher.cranelift-frontend]]
 version = "0.108.1"
 when = "2024-05-22"
+user-id = 73222
+user-login = "wasmtime-publish"
+
+[[publisher.cranelift-frontend]]
+version = "0.109.0"
+when = "2024-06-20"
 user-id = 73222
 user-login = "wasmtime-publish"
 
@@ -1128,6 +1356,12 @@ when = "2024-05-22"
 user-id = 73222
 user-login = "wasmtime-publish"
 
+[[publisher.cranelift-interpreter]]
+version = "0.109.0"
+when = "2024-06-20"
+user-id = 73222
+user-login = "wasmtime-publish"
+
 [[publisher.cranelift-isle]]
 version = "0.105.2"
 when = "2024-02-28"
@@ -1149,6 +1383,12 @@ user-login = "wasmtime-publish"
 [[publisher.cranelift-isle]]
 version = "0.108.1"
 when = "2024-05-22"
+user-id = 73222
+user-login = "wasmtime-publish"
+
+[[publisher.cranelift-isle]]
+version = "0.109.0"
+when = "2024-06-20"
 user-id = 73222
 user-login = "wasmtime-publish"
 
@@ -1176,6 +1416,12 @@ when = "2024-05-22"
 user-id = 73222
 user-login = "wasmtime-publish"
 
+[[publisher.cranelift-jit]]
+version = "0.109.0"
+when = "2024-06-20"
+user-id = 73222
+user-login = "wasmtime-publish"
+
 [[publisher.cranelift-module]]
 version = "0.105.2"
 when = "2024-02-28"
@@ -1197,6 +1443,12 @@ user-login = "wasmtime-publish"
 [[publisher.cranelift-module]]
 version = "0.108.1"
 when = "2024-05-22"
+user-id = 73222
+user-login = "wasmtime-publish"
+
+[[publisher.cranelift-module]]
+version = "0.109.0"
+when = "2024-06-20"
 user-id = 73222
 user-login = "wasmtime-publish"
 
@@ -1224,6 +1476,12 @@ when = "2024-05-22"
 user-id = 73222
 user-login = "wasmtime-publish"
 
+[[publisher.cranelift-native]]
+version = "0.109.0"
+when = "2024-06-20"
+user-id = 73222
+user-login = "wasmtime-publish"
+
 [[publisher.cranelift-object]]
 version = "0.105.2"
 when = "2024-02-28"
@@ -1245,6 +1503,12 @@ user-login = "wasmtime-publish"
 [[publisher.cranelift-object]]
 version = "0.108.1"
 when = "2024-05-22"
+user-id = 73222
+user-login = "wasmtime-publish"
+
+[[publisher.cranelift-object]]
+version = "0.109.0"
+when = "2024-06-20"
 user-id = 73222
 user-login = "wasmtime-publish"
 
@@ -1272,6 +1536,12 @@ when = "2024-05-22"
 user-id = 73222
 user-login = "wasmtime-publish"
 
+[[publisher.cranelift-reader]]
+version = "0.109.0"
+when = "2024-06-20"
+user-id = 73222
+user-login = "wasmtime-publish"
+
 [[publisher.cranelift-serde]]
 version = "0.105.2"
 when = "2024-02-28"
@@ -1296,6 +1566,12 @@ when = "2024-05-22"
 user-id = 73222
 user-login = "wasmtime-publish"
 
+[[publisher.cranelift-serde]]
+version = "0.109.0"
+when = "2024-06-20"
+user-id = 73222
+user-login = "wasmtime-publish"
+
 [[publisher.cranelift-wasm]]
 version = "0.105.2"
 when = "2024-02-28"
@@ -1317,6 +1593,12 @@ user-login = "wasmtime-publish"
 [[publisher.cranelift-wasm]]
 version = "0.108.1"
 when = "2024-05-22"
+user-id = 73222
+user-login = "wasmtime-publish"
+
+[[publisher.cranelift-wasm]]
+version = "0.109.0"
+when = "2024-06-20"
 user-id = 73222
 user-login = "wasmtime-publish"
 
@@ -1749,6 +2031,12 @@ when = "2024-05-22"
 user-id = 73222
 user-login = "wasmtime-publish"
 
+[[publisher.wasi-common]]
+version = "22.0.0"
+when = "2024-06-20"
+user-id = 73222
+user-login = "wasmtime-publish"
+
 [[publisher.wasm-bindgen]]
 version = "0.2.87"
 when = "2023-06-12"
@@ -2120,6 +2408,12 @@ when = "2024-05-22"
 user-id = 73222
 user-login = "wasmtime-publish"
 
+[[publisher.wasmtime]]
+version = "22.0.0"
+when = "2024-06-20"
+user-id = 73222
+user-login = "wasmtime-publish"
+
 [[publisher.wasmtime-asm-macros]]
 version = "18.0.2"
 when = "2024-02-28"
@@ -2141,6 +2435,12 @@ user-login = "wasmtime-publish"
 [[publisher.wasmtime-asm-macros]]
 version = "21.0.1"
 when = "2024-05-22"
+user-id = 73222
+user-login = "wasmtime-publish"
+
+[[publisher.wasmtime-asm-macros]]
+version = "22.0.0"
+when = "2024-06-20"
 user-id = 73222
 user-login = "wasmtime-publish"
 
@@ -2168,6 +2468,12 @@ when = "2024-05-22"
 user-id = 73222
 user-login = "wasmtime-publish"
 
+[[publisher.wasmtime-cache]]
+version = "22.0.0"
+when = "2024-06-20"
+user-id = 73222
+user-login = "wasmtime-publish"
+
 [[publisher.wasmtime-cli]]
 version = "18.0.2"
 when = "2024-02-28"
@@ -2189,6 +2495,12 @@ user-login = "wasmtime-publish"
 [[publisher.wasmtime-cli]]
 version = "21.0.1"
 when = "2024-05-22"
+user-id = 73222
+user-login = "wasmtime-publish"
+
+[[publisher.wasmtime-cli]]
+version = "22.0.0"
+when = "2024-06-20"
 user-id = 73222
 user-login = "wasmtime-publish"
 
@@ -2216,6 +2528,12 @@ when = "2024-05-22"
 user-id = 73222
 user-login = "wasmtime-publish"
 
+[[publisher.wasmtime-cli-flags]]
+version = "22.0.0"
+when = "2024-06-20"
+user-id = 73222
+user-login = "wasmtime-publish"
+
 [[publisher.wasmtime-component-macro]]
 version = "18.0.2"
 when = "2024-02-28"
@@ -2237,6 +2555,12 @@ user-login = "wasmtime-publish"
 [[publisher.wasmtime-component-macro]]
 version = "21.0.1"
 when = "2024-05-22"
+user-id = 73222
+user-login = "wasmtime-publish"
+
+[[publisher.wasmtime-component-macro]]
+version = "22.0.0"
+when = "2024-06-20"
 user-id = 73222
 user-login = "wasmtime-publish"
 
@@ -2264,6 +2588,12 @@ when = "2024-05-22"
 user-id = 73222
 user-login = "wasmtime-publish"
 
+[[publisher.wasmtime-component-util]]
+version = "22.0.0"
+when = "2024-06-20"
+user-id = 73222
+user-login = "wasmtime-publish"
+
 [[publisher.wasmtime-cranelift]]
 version = "18.0.2"
 when = "2024-02-28"
@@ -2285,6 +2615,12 @@ user-login = "wasmtime-publish"
 [[publisher.wasmtime-cranelift]]
 version = "21.0.1"
 when = "2024-05-22"
+user-id = 73222
+user-login = "wasmtime-publish"
+
+[[publisher.wasmtime-cranelift]]
+version = "22.0.0"
+when = "2024-06-20"
 user-id = 73222
 user-login = "wasmtime-publish"
 
@@ -2312,6 +2648,12 @@ when = "2024-05-22"
 user-id = 73222
 user-login = "wasmtime-publish"
 
+[[publisher.wasmtime-environ]]
+version = "22.0.0"
+when = "2024-06-20"
+user-id = 73222
+user-login = "wasmtime-publish"
+
 [[publisher.wasmtime-explorer]]
 version = "18.0.2"
 when = "2024-02-28"
@@ -2333,6 +2675,12 @@ user-login = "wasmtime-publish"
 [[publisher.wasmtime-explorer]]
 version = "21.0.1"
 when = "2024-05-22"
+user-id = 73222
+user-login = "wasmtime-publish"
+
+[[publisher.wasmtime-explorer]]
+version = "22.0.0"
+when = "2024-06-20"
 user-id = 73222
 user-login = "wasmtime-publish"
 
@@ -2360,6 +2708,12 @@ when = "2024-05-22"
 user-id = 73222
 user-login = "wasmtime-publish"
 
+[[publisher.wasmtime-fiber]]
+version = "22.0.0"
+when = "2024-06-20"
+user-id = 73222
+user-login = "wasmtime-publish"
+
 [[publisher.wasmtime-jit-debug]]
 version = "18.0.2"
 when = "2024-02-28"
@@ -2384,6 +2738,12 @@ when = "2024-05-22"
 user-id = 73222
 user-login = "wasmtime-publish"
 
+[[publisher.wasmtime-jit-debug]]
+version = "22.0.0"
+when = "2024-06-20"
+user-id = 73222
+user-login = "wasmtime-publish"
+
 [[publisher.wasmtime-jit-icache-coherence]]
 version = "18.0.2"
 when = "2024-02-28"
@@ -2405,6 +2765,12 @@ user-login = "wasmtime-publish"
 [[publisher.wasmtime-jit-icache-coherence]]
 version = "21.0.1"
 when = "2024-05-22"
+user-id = 73222
+user-login = "wasmtime-publish"
+
+[[publisher.wasmtime-jit-icache-coherence]]
+version = "22.0.0"
+when = "2024-06-20"
 user-id = 73222
 user-login = "wasmtime-publish"
 
@@ -2432,6 +2798,12 @@ when = "2024-05-22"
 user-id = 73222
 user-login = "wasmtime-publish"
 
+[[publisher.wasmtime-slab]]
+version = "22.0.0"
+when = "2024-06-20"
+user-id = 73222
+user-login = "wasmtime-publish"
+
 [[publisher.wasmtime-types]]
 version = "18.0.2"
 when = "2024-02-28"
@@ -2453,6 +2825,12 @@ user-login = "wasmtime-publish"
 [[publisher.wasmtime-types]]
 version = "21.0.1"
 when = "2024-05-22"
+user-id = 73222
+user-login = "wasmtime-publish"
+
+[[publisher.wasmtime-types]]
+version = "22.0.0"
+when = "2024-06-20"
 user-id = 73222
 user-login = "wasmtime-publish"
 
@@ -2480,6 +2858,12 @@ when = "2024-05-22"
 user-id = 73222
 user-login = "wasmtime-publish"
 
+[[publisher.wasmtime-wasi]]
+version = "22.0.0"
+when = "2024-06-20"
+user-id = 73222
+user-login = "wasmtime-publish"
+
 [[publisher.wasmtime-wasi-http]]
 version = "18.0.2"
 when = "2024-02-28"
@@ -2501,6 +2885,12 @@ user-login = "wasmtime-publish"
 [[publisher.wasmtime-wasi-http]]
 version = "21.0.1"
 when = "2024-05-22"
+user-id = 73222
+user-login = "wasmtime-publish"
+
+[[publisher.wasmtime-wasi-http]]
+version = "22.0.0"
+when = "2024-06-20"
 user-id = 73222
 user-login = "wasmtime-publish"
 
@@ -2528,6 +2918,12 @@ when = "2024-05-22"
 user-id = 73222
 user-login = "wasmtime-publish"
 
+[[publisher.wasmtime-wasi-nn]]
+version = "22.0.0"
+when = "2024-06-20"
+user-id = 73222
+user-login = "wasmtime-publish"
+
 [[publisher.wasmtime-wasi-threads]]
 version = "18.0.2"
 when = "2024-02-28"
@@ -2549,6 +2945,12 @@ user-login = "wasmtime-publish"
 [[publisher.wasmtime-wasi-threads]]
 version = "21.0.1"
 when = "2024-05-22"
+user-id = 73222
+user-login = "wasmtime-publish"
+
+[[publisher.wasmtime-wasi-threads]]
+version = "22.0.0"
+when = "2024-06-20"
 user-id = 73222
 user-login = "wasmtime-publish"
 
@@ -2576,6 +2978,12 @@ when = "2024-05-22"
 user-id = 73222
 user-login = "wasmtime-publish"
 
+[[publisher.wasmtime-wast]]
+version = "22.0.0"
+when = "2024-06-20"
+user-id = 73222
+user-login = "wasmtime-publish"
+
 [[publisher.wasmtime-winch]]
 version = "18.0.2"
 when = "2024-02-28"
@@ -2600,6 +3008,12 @@ when = "2024-05-22"
 user-id = 73222
 user-login = "wasmtime-publish"
 
+[[publisher.wasmtime-winch]]
+version = "22.0.0"
+when = "2024-06-20"
+user-id = 73222
+user-login = "wasmtime-publish"
+
 [[publisher.wasmtime-wit-bindgen]]
 version = "18.0.2"
 when = "2024-02-28"
@@ -2624,6 +3038,12 @@ when = "2024-05-22"
 user-id = 73222
 user-login = "wasmtime-publish"
 
+[[publisher.wasmtime-wit-bindgen]]
+version = "22.0.0"
+when = "2024-06-20"
+user-id = 73222
+user-login = "wasmtime-publish"
+
 [[publisher.wasmtime-wmemcheck]]
 version = "18.0.2"
 when = "2024-02-28"
@@ -2645,6 +3065,12 @@ user-login = "wasmtime-publish"
 [[publisher.wasmtime-wmemcheck]]
 version = "21.0.1"
 when = "2024-05-22"
+user-id = 73222
+user-login = "wasmtime-publish"
+
+[[publisher.wasmtime-wmemcheck]]
+version = "22.0.0"
+when = "2024-06-20"
 user-id = 73222
 user-login = "wasmtime-publish"
 
@@ -2792,6 +3218,12 @@ when = "2024-05-22"
 user-id = 73222
 user-login = "wasmtime-publish"
 
+[[publisher.wiggle]]
+version = "22.0.0"
+when = "2024-06-20"
+user-id = 73222
+user-login = "wasmtime-publish"
+
 [[publisher.wiggle-generate]]
 version = "18.0.2"
 when = "2024-02-28"
@@ -2816,6 +3248,12 @@ when = "2024-05-22"
 user-id = 73222
 user-login = "wasmtime-publish"
 
+[[publisher.wiggle-generate]]
+version = "22.0.0"
+when = "2024-06-20"
+user-id = 73222
+user-login = "wasmtime-publish"
+
 [[publisher.wiggle-macro]]
 version = "18.0.2"
 when = "2024-02-28"
@@ -2837,6 +3275,12 @@ user-login = "wasmtime-publish"
 [[publisher.wiggle-macro]]
 version = "21.0.1"
 when = "2024-05-22"
+user-id = 73222
+user-login = "wasmtime-publish"
+
+[[publisher.wiggle-macro]]
+version = "22.0.0"
+when = "2024-06-20"
 user-id = 73222
 user-login = "wasmtime-publish"
 
@@ -2875,6 +3319,12 @@ user-login = "wasmtime-publish"
 [[publisher.winch-codegen]]
 version = "0.19.1"
 when = "2024-05-22"
+user-id = 73222
+user-login = "wasmtime-publish"
+
+[[publisher.winch-codegen]]
+version = "0.20.0"
+when = "2024-06-20"
 user-id = 73222
 user-login = "wasmtime-publish"
 

--- a/winch/codegen/Cargo.toml
+++ b/winch/codegen/Cargo.toml
@@ -4,7 +4,7 @@ name = "winch-codegen"
 description = "Winch code generation library"
 license = "Apache-2.0 WITH LLVM-exception"
 repository = "https://github.com/bytecodealliance/wasmtime"
-version = "0.21.0"
+version = "0.22.0"
 edition.workspace = true
 
 [lints]


### PR DESCRIPTION
This is an [automated pull request][process] from CI which indicates that the next [`release-23.0.0` branch][branch] has been created and the `main` branch is getting its version number bumped from 23.0.0 to 24.0.0.

Maintainers should take a moment to review the [release notes][RELEASES.md] for 23.0.0 and any updates should be made directly to the [release branch][branch].

Another automated PR will be made in roughly 2 weeks time when for the actual release itself.

If any issues arise on the `main` branch before the release is made then the issue should first be fixed on `main` and then backport to the `release-23.0.0` branch.

[RELEASES.md]: https://github.com/juntyr/wasmtime/blob/release-23.0.0/RELEASES.md
[branch]: https://github.com/juntyr/wasmtime/tree/release-23.0.0
[process]: https://docs.wasmtime.dev/contributing-release-process.html
