### PR TITLE
Release Wasmtime 24.0.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -216,7 +216,7 @@ checksum = "7f30e7476521f6f8af1a1c4c0b8cc94f0bee37d91763d0ca2665f299b6cd8aec"
 
 [[package]]
 name = "byte-array-literals"
-version = "24.0.0"
+version = "24.0.1"
 
 [[package]]
 name = "byteorder"
@@ -578,7 +578,7 @@ dependencies = [
 
 [[package]]
 name = "cranelift"
-version = "0.111.0"
+version = "0.111.1"
 dependencies = [
  "cranelift-codegen",
  "cranelift-frontend",
@@ -591,14 +591,14 @@ dependencies = [
 
 [[package]]
 name = "cranelift-bforest"
-version = "0.111.0"
+version = "0.111.1"
 dependencies = [
  "cranelift-entity",
 ]
 
 [[package]]
 name = "cranelift-bitset"
-version = "0.111.0"
+version = "0.111.1"
 dependencies = [
  "serde",
  "serde_derive",
@@ -606,7 +606,7 @@ dependencies = [
 
 [[package]]
 name = "cranelift-codegen"
-version = "0.111.0"
+version = "0.111.1"
 dependencies = [
  "anyhow",
  "bumpalo",
@@ -637,25 +637,25 @@ dependencies = [
 
 [[package]]
 name = "cranelift-codegen-meta"
-version = "0.111.0"
+version = "0.111.1"
 dependencies = [
  "cranelift-codegen-shared",
 ]
 
 [[package]]
 name = "cranelift-codegen-shared"
-version = "0.111.0"
+version = "0.111.1"
 
 [[package]]
 name = "cranelift-control"
-version = "0.111.0"
+version = "0.111.1"
 dependencies = [
  "arbitrary",
 ]
 
 [[package]]
 name = "cranelift-entity"
-version = "0.111.0"
+version = "0.111.1"
 dependencies = [
  "cranelift-bitset",
  "serde",
@@ -693,7 +693,7 @@ dependencies = [
 
 [[package]]
 name = "cranelift-frontend"
-version = "0.111.0"
+version = "0.111.1"
 dependencies = [
  "cranelift-codegen",
  "hashbrown 0.14.3",
@@ -717,7 +717,7 @@ dependencies = [
 
 [[package]]
 name = "cranelift-interpreter"
-version = "0.111.0"
+version = "0.111.1"
 dependencies = [
  "cranelift-codegen",
  "cranelift-entity",
@@ -731,7 +731,7 @@ dependencies = [
 
 [[package]]
 name = "cranelift-isle"
-version = "0.111.0"
+version = "0.111.1"
 dependencies = [
  "codespan-reporting",
  "log",
@@ -740,7 +740,7 @@ dependencies = [
 
 [[package]]
 name = "cranelift-jit"
-version = "0.111.0"
+version = "0.111.1"
 dependencies = [
  "anyhow",
  "cranelift",
@@ -761,7 +761,7 @@ dependencies = [
 
 [[package]]
 name = "cranelift-module"
-version = "0.111.0"
+version = "0.111.1"
 dependencies = [
  "anyhow",
  "cranelift-codegen",
@@ -773,7 +773,7 @@ dependencies = [
 
 [[package]]
 name = "cranelift-native"
-version = "0.111.0"
+version = "0.111.1"
 dependencies = [
  "cranelift-codegen",
  "libc",
@@ -782,7 +782,7 @@ dependencies = [
 
 [[package]]
 name = "cranelift-object"
-version = "0.111.0"
+version = "0.111.1"
 dependencies = [
  "anyhow",
  "cranelift-codegen",
@@ -797,7 +797,7 @@ dependencies = [
 
 [[package]]
 name = "cranelift-reader"
-version = "0.111.0"
+version = "0.111.1"
 dependencies = [
  "anyhow",
  "cranelift-codegen",
@@ -807,7 +807,7 @@ dependencies = [
 
 [[package]]
 name = "cranelift-serde"
-version = "0.111.0"
+version = "0.111.1"
 dependencies = [
  "clap",
  "cranelift-codegen",
@@ -851,7 +851,7 @@ dependencies = [
 
 [[package]]
 name = "cranelift-wasm"
-version = "0.111.0"
+version = "0.111.1"
 dependencies = [
  "cranelift-codegen",
  "cranelift-entity",
@@ -1066,7 +1066,7 @@ checksum = "ef1a6892d9eef45c8fa6b9e0086428a2cca8491aca8f787c534a3d6d0bcb3ced"
 
 [[package]]
 name = "embedding"
-version = "24.0.0"
+version = "24.0.1"
 dependencies = [
  "anyhow",
  "dlmalloc",
@@ -1868,7 +1868,7 @@ dependencies = [
 
 [[package]]
 name = "min-platform-host"
-version = "24.0.0"
+version = "24.0.1"
 dependencies = [
  "anyhow",
  "libloading",
@@ -3100,7 +3100,7 @@ checksum = "830b7e5d4d90034032940e4ace0d9a9a057e7a45cd94e6c007832e39edb82f6d"
 
 [[package]]
 name = "verify-component-adapter"
-version = "24.0.0"
+version = "24.0.1"
 dependencies = [
  "anyhow",
  "wasmparser 0.211.1",
@@ -3150,7 +3150,7 @@ checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
 name = "wasi-common"
-version = "24.0.0"
+version = "24.0.1"
 dependencies = [
  "anyhow",
  "bitflags 2.4.1",
@@ -3190,7 +3190,7 @@ dependencies = [
 
 [[package]]
 name = "wasi-preview1-component-adapter"
-version = "24.0.0"
+version = "24.0.1"
 dependencies = [
  "bitflags 2.4.1",
  "byte-array-literals",
@@ -3422,7 +3422,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime"
-version = "24.0.0"
+version = "24.0.1"
 dependencies = [
  "addr2line",
  "anyhow",
@@ -3482,14 +3482,14 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-asm-macros"
-version = "24.0.0"
+version = "24.0.1"
 dependencies = [
  "cfg-if",
 ]
 
 [[package]]
 name = "wasmtime-bench-api"
-version = "24.0.0"
+version = "24.0.1"
 dependencies = [
  "anyhow",
  "cap-std",
@@ -3505,14 +3505,14 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-c-api"
-version = "24.0.0"
+version = "24.0.1"
 dependencies = [
  "wasmtime-c-api-impl",
 ]
 
 [[package]]
 name = "wasmtime-c-api-impl"
-version = "24.0.0"
+version = "24.0.1"
 dependencies = [
  "anyhow",
  "cap-std",
@@ -3530,7 +3530,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-c-api-macros"
-version = "24.0.0"
+version = "24.0.1"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3538,7 +3538,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-cache"
-version = "24.0.0"
+version = "24.0.1"
 dependencies = [
  "anyhow",
  "base64",
@@ -3560,7 +3560,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-cli"
-version = "24.0.0"
+version = "24.0.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3626,7 +3626,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-cli-flags"
-version = "24.0.0"
+version = "24.0.1"
 dependencies = [
  "anyhow",
  "clap",
@@ -3639,7 +3639,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-component-macro"
-version = "24.0.0"
+version = "24.0.1"
 dependencies = [
  "anyhow",
  "component-macro-test-helpers",
@@ -3659,11 +3659,11 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-component-util"
-version = "24.0.0"
+version = "24.0.1"
 
 [[package]]
 name = "wasmtime-cranelift"
-version = "24.0.0"
+version = "24.0.1"
 dependencies = [
  "anyhow",
  "cfg-if",
@@ -3685,7 +3685,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-environ"
-version = "24.0.0"
+version = "24.0.1"
 dependencies = [
  "anyhow",
  "clap",
@@ -3727,7 +3727,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-explorer"
-version = "24.0.0"
+version = "24.0.1"
 dependencies = [
  "anyhow",
  "capstone",
@@ -3742,7 +3742,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-fiber"
-version = "24.0.0"
+version = "24.0.1"
 dependencies = [
  "anyhow",
  "backtrace",
@@ -3812,7 +3812,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-jit-debug"
-version = "24.0.0"
+version = "24.0.1"
 dependencies = [
  "object 0.36.0",
  "once_cell",
@@ -3822,7 +3822,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-jit-icache-coherence"
-version = "24.0.0"
+version = "24.0.1"
 dependencies = [
  "anyhow",
  "cfg-if",
@@ -3832,7 +3832,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-slab"
-version = "24.0.0"
+version = "24.0.1"
 
 [[package]]
 name = "wasmtime-test-macros"
@@ -3846,7 +3846,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-types"
-version = "24.0.0"
+version = "24.0.1"
 dependencies = [
  "anyhow",
  "cranelift-entity",
@@ -3858,7 +3858,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-versioned-export-macros"
-version = "24.0.0"
+version = "24.0.1"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3867,7 +3867,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-wasi"
-version = "24.0.0"
+version = "24.0.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3900,7 +3900,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-wasi-http"
-version = "24.0.0"
+version = "24.0.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3926,7 +3926,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-wasi-nn"
-version = "24.0.0"
+version = "24.0.1"
 dependencies = [
  "anyhow",
  "cap-std",
@@ -3945,7 +3945,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-wasi-threads"
-version = "24.0.0"
+version = "24.0.1"
 dependencies = [
  "anyhow",
  "log",
@@ -3956,7 +3956,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-wast"
-version = "24.0.0"
+version = "24.0.1"
 dependencies = [
  "anyhow",
  "log",
@@ -3966,7 +3966,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-winch"
-version = "24.0.0"
+version = "24.0.1"
 dependencies = [
  "anyhow",
  "cranelift-codegen",
@@ -3981,7 +3981,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-wit-bindgen"
-version = "24.0.0"
+version = "24.0.1"
 dependencies = [
  "anyhow",
  "heck 0.4.0",
@@ -3991,7 +3991,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-wmemcheck"
-version = "24.0.0"
+version = "24.0.1"
 
 [[package]]
 name = "wast"
@@ -4048,7 +4048,7 @@ dependencies = [
 
 [[package]]
 name = "wiggle"
-version = "24.0.0"
+version = "24.0.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4065,7 +4065,7 @@ dependencies = [
 
 [[package]]
 name = "wiggle-generate"
-version = "24.0.0"
+version = "24.0.1"
 dependencies = [
  "anyhow",
  "heck 0.4.0",
@@ -4078,7 +4078,7 @@ dependencies = [
 
 [[package]]
 name = "wiggle-macro"
-version = "24.0.0"
+version = "24.0.1"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4133,7 +4133,7 @@ checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "winch-codegen"
-version = "0.22.0"
+version = "0.22.1"
 dependencies = [
  "anyhow",
  "cranelift-codegen",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -153,7 +153,7 @@ exclude = [
 ]
 
 [workspace.package]
-version = "24.0.0"
+version = "24.0.1"
 authors = ["The Wasmtime Project Developers"]
 edition = "2021"
 # Wasmtime's current policy is that this number can be no larger than the
@@ -176,57 +176,57 @@ all = 'allow'
 
 [workspace.dependencies]
 arbitrary = { version = "1.3.1" }
-wasmtime-wmemcheck = { path = "crates/wmemcheck", version = "=24.0.0" }
-wasmtime = { path = "crates/wasmtime", version = "24.0.0", default-features = false }
-wasmtime-c-api-macros = { path = "crates/c-api-macros", version = "=24.0.0" }
-wasmtime-cache = { path = "crates/cache", version = "=24.0.0" }
-wasmtime-cli-flags = { path = "crates/cli-flags", version = "=24.0.0" }
-wasmtime-cranelift = { path = "crates/cranelift", version = "=24.0.0" }
-wasmtime-winch = { path = "crates/winch", version = "=24.0.0" }
-wasmtime-environ = { path = "crates/environ", version = "=24.0.0" }
-wasmtime-explorer = { path = "crates/explorer", version = "=24.0.0" }
-wasmtime-fiber = { path = "crates/fiber", version = "=24.0.0" }
-wasmtime-types = { path = "crates/types", version = "24.0.0" }
-wasmtime-jit-debug = { path = "crates/jit-debug", version = "=24.0.0" }
-wasmtime-wast = { path = "crates/wast", version = "=24.0.0" }
-wasmtime-wasi = { path = "crates/wasi", version = "24.0.0", default-features = false }
-wasmtime-wasi-http = { path = "crates/wasi-http", version = "=24.0.0", default-features = false }
-wasmtime-wasi-nn = { path = "crates/wasi-nn", version = "24.0.0" }
-wasmtime-wasi-threads = { path = "crates/wasi-threads", version = "24.0.0" }
-wasmtime-component-util = { path = "crates/component-util", version = "=24.0.0" }
-wasmtime-component-macro = { path = "crates/component-macro", version = "=24.0.0" }
-wasmtime-asm-macros = { path = "crates/asm-macros", version = "=24.0.0" }
-wasmtime-versioned-export-macros = { path = "crates/versioned-export-macros", version = "=24.0.0" }
-wasmtime-slab = { path = "crates/slab", version = "=24.0.0" }
+wasmtime-wmemcheck = { path = "crates/wmemcheck", version = "=24.0.1" }
+wasmtime = { path = "crates/wasmtime", version = "24.0.1", default-features = false }
+wasmtime-c-api-macros = { path = "crates/c-api-macros", version = "=24.0.1" }
+wasmtime-cache = { path = "crates/cache", version = "=24.0.1" }
+wasmtime-cli-flags = { path = "crates/cli-flags", version = "=24.0.1" }
+wasmtime-cranelift = { path = "crates/cranelift", version = "=24.0.1" }
+wasmtime-winch = { path = "crates/winch", version = "=24.0.1" }
+wasmtime-environ = { path = "crates/environ", version = "=24.0.1" }
+wasmtime-explorer = { path = "crates/explorer", version = "=24.0.1" }
+wasmtime-fiber = { path = "crates/fiber", version = "=24.0.1" }
+wasmtime-types = { path = "crates/types", version = "24.0.1" }
+wasmtime-jit-debug = { path = "crates/jit-debug", version = "=24.0.1" }
+wasmtime-wast = { path = "crates/wast", version = "=24.0.1" }
+wasmtime-wasi = { path = "crates/wasi", version = "24.0.1", default-features = false }
+wasmtime-wasi-http = { path = "crates/wasi-http", version = "=24.0.1", default-features = false }
+wasmtime-wasi-nn = { path = "crates/wasi-nn", version = "24.0.1" }
+wasmtime-wasi-threads = { path = "crates/wasi-threads", version = "24.0.1" }
+wasmtime-component-util = { path = "crates/component-util", version = "=24.0.1" }
+wasmtime-component-macro = { path = "crates/component-macro", version = "=24.0.1" }
+wasmtime-asm-macros = { path = "crates/asm-macros", version = "=24.0.1" }
+wasmtime-versioned-export-macros = { path = "crates/versioned-export-macros", version = "=24.0.1" }
+wasmtime-slab = { path = "crates/slab", version = "=24.0.1" }
 component-test-util = { path = "crates/misc/component-test-util" }
 component-fuzz-util = { path = "crates/misc/component-fuzz-util" }
-wiggle = { path = "crates/wiggle", version = "=24.0.0", default-features = false }
-wiggle-macro = { path = "crates/wiggle/macro", version = "=24.0.0" }
-wiggle-generate = { path = "crates/wiggle/generate", version = "=24.0.0" }
-wasi-common = { path = "crates/wasi-common", version = "=24.0.0", default-features = false }
+wiggle = { path = "crates/wiggle", version = "=24.0.1", default-features = false }
+wiggle-macro = { path = "crates/wiggle/macro", version = "=24.0.1" }
+wiggle-generate = { path = "crates/wiggle/generate", version = "=24.0.1" }
+wasi-common = { path = "crates/wasi-common", version = "=24.0.1", default-features = false }
 wasmtime-fuzzing = { path = "crates/fuzzing" }
-wasmtime-jit-icache-coherence = { path = "crates/jit-icache-coherence", version = "=24.0.0" }
-wasmtime-wit-bindgen = { path = "crates/wit-bindgen", version = "=24.0.0" }
+wasmtime-jit-icache-coherence = { path = "crates/jit-icache-coherence", version = "=24.0.1" }
+wasmtime-wit-bindgen = { path = "crates/wit-bindgen", version = "=24.0.1" }
 test-programs-artifacts = { path = 'crates/test-programs/artifacts' }
 
-cranelift-wasm = { path = "cranelift/wasm", version = "0.111.0" }
-cranelift-codegen = { path = "cranelift/codegen", version = "0.111.0", default-features = false, features = ["std", "unwind", "trace-log"] }
-cranelift-frontend = { path = "cranelift/frontend", version = "0.111.0" }
-cranelift-entity = { path = "cranelift/entity", version = "0.111.0" }
-cranelift-native = { path = "cranelift/native", version = "0.111.0" }
-cranelift-module = { path = "cranelift/module", version = "0.111.0" }
-cranelift-interpreter = { path = "cranelift/interpreter", version = "0.111.0" }
-cranelift-reader = { path = "cranelift/reader", version = "0.111.0" }
+cranelift-wasm = { path = "cranelift/wasm", version = "0.111.1" }
+cranelift-codegen = { path = "cranelift/codegen", version = "0.111.1", default-features = false, features = ["std", "unwind", "trace-log"] }
+cranelift-frontend = { path = "cranelift/frontend", version = "0.111.1" }
+cranelift-entity = { path = "cranelift/entity", version = "0.111.1" }
+cranelift-native = { path = "cranelift/native", version = "0.111.1" }
+cranelift-module = { path = "cranelift/module", version = "0.111.1" }
+cranelift-interpreter = { path = "cranelift/interpreter", version = "0.111.1" }
+cranelift-reader = { path = "cranelift/reader", version = "0.111.1" }
 cranelift-filetests = { path = "cranelift/filetests" }
-cranelift-object = { path = "cranelift/object", version = "0.111.0" }
-cranelift-jit = { path = "cranelift/jit", version = "0.111.0" }
+cranelift-object = { path = "cranelift/object", version = "0.111.1" }
+cranelift-jit = { path = "cranelift/jit", version = "0.111.1" }
 cranelift-fuzzgen = { path = "cranelift/fuzzgen" }
-cranelift-bforest = { path = "cranelift/bforest", version = "0.111.0" }
-cranelift-bitset = { path = "cranelift/bitset", version = "0.111.0" }
-cranelift-control = { path = "cranelift/control", version = "0.111.0" }
-cranelift = { path = "cranelift/umbrella", version = "0.111.0" }
+cranelift-bforest = { path = "cranelift/bforest", version = "0.111.1" }
+cranelift-bitset = { path = "cranelift/bitset", version = "0.111.1" }
+cranelift-control = { path = "cranelift/control", version = "0.111.1" }
+cranelift = { path = "cranelift/umbrella", version = "0.111.1" }
 
-winch-codegen = { path = "winch/codegen", version = "=0.22.0" }
+winch-codegen = { path = "winch/codegen", version = "=0.22.1" }
 
 wasi-preview1-component-adapter = { path = "crates/wasi-preview1-component-adapter" }
 byte-array-literals = { path = "crates/wasi-preview1-component-adapter/byte-array-literals" }

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -1,6 +1,6 @@
 ## 24.0.0
 
-Unreleased.
+Released 2024-06-28.
 
 ### Added
 

--- a/cranelift/bforest/Cargo.toml
+++ b/cranelift/bforest/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["The Cranelift Project Developers"]
 name = "cranelift-bforest"
-version = "0.111.0"
+version = "0.111.1"
 description = "A forest of B+-trees"
 license = "Apache-2.0 WITH LLVM-exception"
 documentation = "https://docs.rs/cranelift-bforest"

--- a/cranelift/bitset/Cargo.toml
+++ b/cranelift/bitset/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["The Cranelift Project Developers"]
 name = "cranelift-bitset"
-version = "0.111.0"
+version = "0.111.1"
 description = "Various bitset stuff for use inside Cranelift"
 license = "Apache-2.0 WITH LLVM-exception"
 documentation = "https://docs.rs/cranelift-bitset"

--- a/cranelift/codegen/Cargo.toml
+++ b/cranelift/codegen/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["The Cranelift Project Developers"]
 name = "cranelift-codegen"
-version = "0.111.0"
+version = "0.111.1"
 description = "Low-level code generator library"
 license = "Apache-2.0 WITH LLVM-exception"
 documentation = "https://docs.rs/cranelift-codegen"
@@ -19,7 +19,7 @@ workspace = true
 anyhow = { workspace = true, optional = true, features = ['std'] }
 bumpalo = "3"
 capstone = { workspace = true, optional = true }
-cranelift-codegen-shared = { path = "./shared", version = "0.111.0" }
+cranelift-codegen-shared = { path = "./shared", version = "0.111.1" }
 cranelift-entity = { workspace = true }
 cranelift-bforest = { workspace = true }
 cranelift-bitset = { workspace = true }
@@ -47,8 +47,8 @@ similar = "2.1.0"
 env_logger = { workspace = true }
 
 [build-dependencies]
-cranelift-codegen-meta = { path = "meta", version = "0.111.0" }
-cranelift-isle = { path = "../isle/isle", version = "=0.111.0" }
+cranelift-codegen-meta = { path = "meta", version = "0.111.1" }
+cranelift-isle = { path = "../isle/isle", version = "=0.111.1" }
 
 [features]
 default = ["std", "unwind", "host-arch", "timing"]

--- a/cranelift/codegen/meta/Cargo.toml
+++ b/cranelift/codegen/meta/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "cranelift-codegen-meta"
 authors = ["The Cranelift Project Developers"]
-version = "0.111.0"
+version = "0.111.1"
 description = "Metaprogram for cranelift-codegen code generator library"
 license = "Apache-2.0 WITH LLVM-exception"
 repository = "https://github.com/bytecodealliance/wasmtime"
@@ -15,4 +15,4 @@ workspace = true
 rustdoc-args = [ "--document-private-items" ]
 
 [dependencies]
-cranelift-codegen-shared = { path = "../shared", version = "0.111.0" }
+cranelift-codegen-shared = { path = "../shared", version = "0.111.1" }

--- a/cranelift/codegen/shared/Cargo.toml
+++ b/cranelift/codegen/shared/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["The Cranelift Project Developers"]
 name = "cranelift-codegen-shared"
-version = "0.111.0"
+version = "0.111.1"
 description = "For code shared between cranelift-codegen-meta and cranelift-codegen"
 license = "Apache-2.0 WITH LLVM-exception"
 repository = "https://github.com/bytecodealliance/wasmtime"

--- a/cranelift/control/Cargo.toml
+++ b/cranelift/control/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["The Cranelift Project Developers"]
 name = "cranelift-control"
-version = "0.111.0"
+version = "0.111.1"
 description = "White-box fuzz testing framework"
 license = "Apache-2.0 WITH LLVM-exception"
 repository = "https://github.com/bytecodealliance/wasmtime"

--- a/cranelift/entity/Cargo.toml
+++ b/cranelift/entity/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["The Cranelift Project Developers"]
 name = "cranelift-entity"
-version = "0.111.0"
+version = "0.111.1"
 description = "Data structures using entity references as mapping keys"
 license = "Apache-2.0 WITH LLVM-exception"
 documentation = "https://docs.rs/cranelift-entity"

--- a/cranelift/frontend/Cargo.toml
+++ b/cranelift/frontend/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["The Cranelift Project Developers"]
 name = "cranelift-frontend"
-version = "0.111.0"
+version = "0.111.1"
 description = "Cranelift IR builder helper"
 license = "Apache-2.0 WITH LLVM-exception"
 documentation = "https://docs.rs/cranelift-frontend"

--- a/cranelift/interpreter/Cargo.toml
+++ b/cranelift/interpreter/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cranelift-interpreter"
-version = "0.111.0"
+version = "0.111.1"
 authors = ["The Cranelift Project Developers"]
 description = "Interpret Cranelift IR"
 repository = "https://github.com/bytecodealliance/wasmtime"

--- a/cranelift/isle/isle/Cargo.toml
+++ b/cranelift/isle/isle/Cargo.toml
@@ -6,7 +6,7 @@ license = "Apache-2.0 WITH LLVM-exception"
 name = "cranelift-isle"
 readme = "../README.md"
 repository = "https://github.com/bytecodealliance/wasmtime/tree/main/cranelift/isle"
-version = "0.111.0"
+version = "0.111.1"
 
 [lints]
 workspace = true

--- a/cranelift/jit/Cargo.toml
+++ b/cranelift/jit/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cranelift-jit"
-version = "0.111.0"
+version = "0.111.1"
 authors = ["The Cranelift Project Developers"]
 description = "A JIT library backed by Cranelift"
 repository = "https://github.com/bytecodealliance/wasmtime"

--- a/cranelift/module/Cargo.toml
+++ b/cranelift/module/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cranelift-module"
-version = "0.111.0"
+version = "0.111.1"
 authors = ["The Cranelift Project Developers"]
 description = "Support for linking functions and data with Cranelift"
 repository = "https://github.com/bytecodealliance/wasmtime"

--- a/cranelift/native/Cargo.toml
+++ b/cranelift/native/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cranelift-native"
-version = "0.111.0"
+version = "0.111.1"
 authors = ["The Cranelift Project Developers"]
 description = "Support for targeting the host with Cranelift"
 documentation = "https://docs.rs/cranelift-native"

--- a/cranelift/object/Cargo.toml
+++ b/cranelift/object/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cranelift-object"
-version = "0.111.0"
+version = "0.111.1"
 authors = ["The Cranelift Project Developers"]
 description = "Emit Cranelift output to native object files with `object`"
 repository = "https://github.com/bytecodealliance/wasmtime"

--- a/cranelift/reader/Cargo.toml
+++ b/cranelift/reader/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["The Cranelift Project Developers"]
 name = "cranelift-reader"
-version = "0.111.0"
+version = "0.111.1"
 description = "Cranelift textual IR reader"
 license = "Apache-2.0 WITH LLVM-exception"
 documentation = "https://docs.rs/cranelift-reader"

--- a/cranelift/serde/Cargo.toml
+++ b/cranelift/serde/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cranelift-serde"
-version = "0.111.0"
+version = "0.111.1"
 authors = ["The Cranelift Project Developers"]
 description = "Serializer/Deserializer for Cranelift IR"
 repository = "https://github.com/bytecodealliance/wasmtime"

--- a/cranelift/umbrella/Cargo.toml
+++ b/cranelift/umbrella/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["The Cranelift Project Developers"]
 name = "cranelift"
-version = "0.111.0"
+version = "0.111.1"
 description = "Umbrella for commonly-used cranelift crates"
 license = "Apache-2.0 WITH LLVM-exception"
 documentation = "https://docs.rs/cranelift"

--- a/cranelift/wasm/Cargo.toml
+++ b/cranelift/wasm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cranelift-wasm"
-version = "0.111.0"
+version = "0.111.1"
 authors = ["The Cranelift Project Developers"]
 description = "Translator from WebAssembly to Cranelift IR"
 documentation = "https://docs.rs/cranelift-wasm"

--- a/crates/c-api/include/wasmtime.h
+++ b/crates/c-api/include/wasmtime.h
@@ -206,7 +206,7 @@
 /**
  * \brief Wasmtime version string.
  */
-#define WASMTIME_VERSION "24.0.0"
+#define WASMTIME_VERSION "24.0.1"
 /**
  * \brief Wasmtime major version number.
  */
@@ -218,7 +218,7 @@
 /**
  * \brief Wasmtime patch version number.
  */
-#define WASMTIME_VERSION_PATCH 0
+#define WASMTIME_VERSION_PATCH 1
 
 #ifdef __cplusplus
 extern "C" {

--- a/supply-chain/imports.lock
+++ b/supply-chain/imports.lock
@@ -21,6 +21,10 @@ audited_as = "0.108.1"
 version = "0.111.0"
 audited_as = "0.109.0"
 
+[[unpublished.cranelift]]
+version = "0.111.1"
+audited_as = "0.109.0"
+
 [[unpublished.cranelift-bforest]]
 version = "0.107.0"
 audited_as = "0.105.2"
@@ -39,6 +43,10 @@ audited_as = "0.108.1"
 
 [[unpublished.cranelift-bforest]]
 version = "0.111.0"
+audited_as = "0.109.0"
+
+[[unpublished.cranelift-bforest]]
+version = "0.111.1"
 audited_as = "0.109.0"
 
 [[unpublished.cranelift-codegen]]
@@ -61,6 +69,10 @@ audited_as = "0.108.1"
 version = "0.111.0"
 audited_as = "0.109.0"
 
+[[unpublished.cranelift-codegen]]
+version = "0.111.1"
+audited_as = "0.109.0"
+
 [[unpublished.cranelift-codegen-meta]]
 version = "0.107.0"
 audited_as = "0.105.2"
@@ -79,6 +91,10 @@ audited_as = "0.108.1"
 
 [[unpublished.cranelift-codegen-meta]]
 version = "0.111.0"
+audited_as = "0.109.0"
+
+[[unpublished.cranelift-codegen-meta]]
+version = "0.111.1"
 audited_as = "0.109.0"
 
 [[unpublished.cranelift-codegen-shared]]
@@ -101,6 +117,10 @@ audited_as = "0.108.1"
 version = "0.111.0"
 audited_as = "0.109.0"
 
+[[unpublished.cranelift-codegen-shared]]
+version = "0.111.1"
+audited_as = "0.109.0"
+
 [[unpublished.cranelift-control]]
 version = "0.107.0"
 audited_as = "0.105.2"
@@ -119,6 +139,10 @@ audited_as = "0.108.1"
 
 [[unpublished.cranelift-control]]
 version = "0.111.0"
+audited_as = "0.109.0"
+
+[[unpublished.cranelift-control]]
+version = "0.111.1"
 audited_as = "0.109.0"
 
 [[unpublished.cranelift-entity]]
@@ -141,6 +165,10 @@ audited_as = "0.108.1"
 version = "0.111.0"
 audited_as = "0.109.0"
 
+[[unpublished.cranelift-entity]]
+version = "0.111.1"
+audited_as = "0.109.0"
+
 [[unpublished.cranelift-frontend]]
 version = "0.107.0"
 audited_as = "0.105.2"
@@ -159,6 +187,10 @@ audited_as = "0.108.1"
 
 [[unpublished.cranelift-frontend]]
 version = "0.111.0"
+audited_as = "0.109.0"
+
+[[unpublished.cranelift-frontend]]
+version = "0.111.1"
 audited_as = "0.109.0"
 
 [[unpublished.cranelift-interpreter]]
@@ -181,6 +213,10 @@ audited_as = "0.108.1"
 version = "0.111.0"
 audited_as = "0.109.0"
 
+[[unpublished.cranelift-interpreter]]
+version = "0.111.1"
+audited_as = "0.109.0"
+
 [[unpublished.cranelift-isle]]
 version = "0.107.0"
 audited_as = "0.105.2"
@@ -199,6 +235,10 @@ audited_as = "0.108.1"
 
 [[unpublished.cranelift-isle]]
 version = "0.111.0"
+audited_as = "0.109.0"
+
+[[unpublished.cranelift-isle]]
+version = "0.111.1"
 audited_as = "0.109.0"
 
 [[unpublished.cranelift-jit]]
@@ -221,6 +261,10 @@ audited_as = "0.108.1"
 version = "0.111.0"
 audited_as = "0.109.0"
 
+[[unpublished.cranelift-jit]]
+version = "0.111.1"
+audited_as = "0.109.0"
+
 [[unpublished.cranelift-module]]
 version = "0.107.0"
 audited_as = "0.105.2"
@@ -239,6 +283,10 @@ audited_as = "0.108.1"
 
 [[unpublished.cranelift-module]]
 version = "0.111.0"
+audited_as = "0.109.0"
+
+[[unpublished.cranelift-module]]
+version = "0.111.1"
 audited_as = "0.109.0"
 
 [[unpublished.cranelift-native]]
@@ -261,6 +309,10 @@ audited_as = "0.108.1"
 version = "0.111.0"
 audited_as = "0.109.0"
 
+[[unpublished.cranelift-native]]
+version = "0.111.1"
+audited_as = "0.109.0"
+
 [[unpublished.cranelift-object]]
 version = "0.107.0"
 audited_as = "0.105.2"
@@ -279,6 +331,10 @@ audited_as = "0.108.1"
 
 [[unpublished.cranelift-object]]
 version = "0.111.0"
+audited_as = "0.109.0"
+
+[[unpublished.cranelift-object]]
+version = "0.111.1"
 audited_as = "0.109.0"
 
 [[unpublished.cranelift-reader]]
@@ -301,6 +357,10 @@ audited_as = "0.108.1"
 version = "0.111.0"
 audited_as = "0.109.0"
 
+[[unpublished.cranelift-reader]]
+version = "0.111.1"
+audited_as = "0.109.0"
+
 [[unpublished.cranelift-serde]]
 version = "0.107.0"
 audited_as = "0.105.2"
@@ -319,6 +379,10 @@ audited_as = "0.108.1"
 
 [[unpublished.cranelift-serde]]
 version = "0.111.0"
+audited_as = "0.109.0"
+
+[[unpublished.cranelift-serde]]
+version = "0.111.1"
 audited_as = "0.109.0"
 
 [[unpublished.cranelift-wasm]]
@@ -341,6 +405,10 @@ audited_as = "0.108.1"
 version = "0.111.0"
 audited_as = "0.109.0"
 
+[[unpublished.cranelift-wasm]]
+version = "0.111.1"
+audited_as = "0.109.0"
+
 [[unpublished.wasi-common]]
 version = "20.0.0"
 audited_as = "18.0.2"
@@ -359,6 +427,10 @@ audited_as = "21.0.1"
 
 [[unpublished.wasi-common]]
 version = "24.0.0"
+audited_as = "22.0.0"
+
+[[unpublished.wasi-common]]
+version = "24.0.1"
 audited_as = "22.0.0"
 
 [[unpublished.wasmtime]]
@@ -381,6 +453,10 @@ audited_as = "21.0.1"
 version = "24.0.0"
 audited_as = "22.0.0"
 
+[[unpublished.wasmtime]]
+version = "24.0.1"
+audited_as = "22.0.0"
+
 [[unpublished.wasmtime-asm-macros]]
 version = "20.0.0"
 audited_as = "18.0.2"
@@ -399,6 +475,10 @@ audited_as = "21.0.1"
 
 [[unpublished.wasmtime-asm-macros]]
 version = "24.0.0"
+audited_as = "22.0.0"
+
+[[unpublished.wasmtime-asm-macros]]
+version = "24.0.1"
 audited_as = "22.0.0"
 
 [[unpublished.wasmtime-cache]]
@@ -421,6 +501,10 @@ audited_as = "21.0.1"
 version = "24.0.0"
 audited_as = "22.0.0"
 
+[[unpublished.wasmtime-cache]]
+version = "24.0.1"
+audited_as = "22.0.0"
+
 [[unpublished.wasmtime-cli]]
 version = "20.0.0"
 audited_as = "18.0.2"
@@ -439,6 +523,10 @@ audited_as = "21.0.1"
 
 [[unpublished.wasmtime-cli]]
 version = "24.0.0"
+audited_as = "22.0.0"
+
+[[unpublished.wasmtime-cli]]
+version = "24.0.1"
 audited_as = "22.0.0"
 
 [[unpublished.wasmtime-cli-flags]]
@@ -461,6 +549,10 @@ audited_as = "21.0.1"
 version = "24.0.0"
 audited_as = "22.0.0"
 
+[[unpublished.wasmtime-cli-flags]]
+version = "24.0.1"
+audited_as = "22.0.0"
+
 [[unpublished.wasmtime-component-macro]]
 version = "20.0.0"
 audited_as = "18.0.2"
@@ -479,6 +571,10 @@ audited_as = "21.0.1"
 
 [[unpublished.wasmtime-component-macro]]
 version = "24.0.0"
+audited_as = "22.0.0"
+
+[[unpublished.wasmtime-component-macro]]
+version = "24.0.1"
 audited_as = "22.0.0"
 
 [[unpublished.wasmtime-component-util]]
@@ -501,6 +597,10 @@ audited_as = "21.0.1"
 version = "24.0.0"
 audited_as = "22.0.0"
 
+[[unpublished.wasmtime-component-util]]
+version = "24.0.1"
+audited_as = "22.0.0"
+
 [[unpublished.wasmtime-cranelift]]
 version = "20.0.0"
 audited_as = "18.0.2"
@@ -519,6 +619,10 @@ audited_as = "21.0.1"
 
 [[unpublished.wasmtime-cranelift]]
 version = "24.0.0"
+audited_as = "22.0.0"
+
+[[unpublished.wasmtime-cranelift]]
+version = "24.0.1"
 audited_as = "22.0.0"
 
 [[unpublished.wasmtime-cranelift-shared]]
@@ -545,6 +649,10 @@ audited_as = "21.0.1"
 version = "24.0.0"
 audited_as = "22.0.0"
 
+[[unpublished.wasmtime-environ]]
+version = "24.0.1"
+audited_as = "22.0.0"
+
 [[unpublished.wasmtime-explorer]]
 version = "20.0.0"
 audited_as = "18.0.2"
@@ -563,6 +671,10 @@ audited_as = "21.0.1"
 
 [[unpublished.wasmtime-explorer]]
 version = "24.0.0"
+audited_as = "22.0.0"
+
+[[unpublished.wasmtime-explorer]]
+version = "24.0.1"
 audited_as = "22.0.0"
 
 [[unpublished.wasmtime-fiber]]
@@ -585,6 +697,10 @@ audited_as = "21.0.1"
 version = "24.0.0"
 audited_as = "22.0.0"
 
+[[unpublished.wasmtime-fiber]]
+version = "24.0.1"
+audited_as = "22.0.0"
+
 [[unpublished.wasmtime-jit-debug]]
 version = "20.0.0"
 audited_as = "18.0.2"
@@ -605,6 +721,10 @@ audited_as = "21.0.1"
 version = "24.0.0"
 audited_as = "22.0.0"
 
+[[unpublished.wasmtime-jit-debug]]
+version = "24.0.1"
+audited_as = "22.0.0"
+
 [[unpublished.wasmtime-jit-icache-coherence]]
 version = "20.0.0"
 audited_as = "18.0.2"
@@ -623,6 +743,10 @@ audited_as = "21.0.1"
 
 [[unpublished.wasmtime-jit-icache-coherence]]
 version = "24.0.0"
+audited_as = "22.0.0"
+
+[[unpublished.wasmtime-jit-icache-coherence]]
+version = "24.0.1"
 audited_as = "22.0.0"
 
 [[unpublished.wasmtime-runtime]]
@@ -653,6 +777,10 @@ audited_as = "21.0.1"
 version = "24.0.0"
 audited_as = "22.0.0"
 
+[[unpublished.wasmtime-slab]]
+version = "24.0.1"
+audited_as = "22.0.0"
+
 [[unpublished.wasmtime-types]]
 version = "20.0.0"
 audited_as = "18.0.2"
@@ -671,6 +799,10 @@ audited_as = "21.0.1"
 
 [[unpublished.wasmtime-types]]
 version = "24.0.0"
+audited_as = "22.0.0"
+
+[[unpublished.wasmtime-types]]
+version = "24.0.1"
 audited_as = "22.0.0"
 
 [[unpublished.wasmtime-wasi]]
@@ -693,6 +825,10 @@ audited_as = "21.0.1"
 version = "24.0.0"
 audited_as = "22.0.0"
 
+[[unpublished.wasmtime-wasi]]
+version = "24.0.1"
+audited_as = "22.0.0"
+
 [[unpublished.wasmtime-wasi-http]]
 version = "20.0.0"
 audited_as = "18.0.2"
@@ -711,6 +847,10 @@ audited_as = "21.0.1"
 
 [[unpublished.wasmtime-wasi-http]]
 version = "24.0.0"
+audited_as = "22.0.0"
+
+[[unpublished.wasmtime-wasi-http]]
+version = "24.0.1"
 audited_as = "22.0.0"
 
 [[unpublished.wasmtime-wasi-nn]]
@@ -733,6 +873,10 @@ audited_as = "21.0.1"
 version = "24.0.0"
 audited_as = "22.0.0"
 
+[[unpublished.wasmtime-wasi-nn]]
+version = "24.0.1"
+audited_as = "22.0.0"
+
 [[unpublished.wasmtime-wasi-threads]]
 version = "20.0.0"
 audited_as = "18.0.2"
@@ -751,6 +895,10 @@ audited_as = "21.0.1"
 
 [[unpublished.wasmtime-wasi-threads]]
 version = "24.0.0"
+audited_as = "22.0.0"
+
+[[unpublished.wasmtime-wasi-threads]]
+version = "24.0.1"
 audited_as = "22.0.0"
 
 [[unpublished.wasmtime-wast]]
@@ -773,6 +921,10 @@ audited_as = "21.0.1"
 version = "24.0.0"
 audited_as = "22.0.0"
 
+[[unpublished.wasmtime-wast]]
+version = "24.0.1"
+audited_as = "22.0.0"
+
 [[unpublished.wasmtime-winch]]
 version = "20.0.0"
 audited_as = "18.0.2"
@@ -791,6 +943,10 @@ audited_as = "21.0.1"
 
 [[unpublished.wasmtime-winch]]
 version = "24.0.0"
+audited_as = "22.0.0"
+
+[[unpublished.wasmtime-winch]]
+version = "24.0.1"
 audited_as = "22.0.0"
 
 [[unpublished.wasmtime-wit-bindgen]]
@@ -813,6 +969,10 @@ audited_as = "21.0.1"
 version = "24.0.0"
 audited_as = "22.0.0"
 
+[[unpublished.wasmtime-wit-bindgen]]
+version = "24.0.1"
+audited_as = "22.0.0"
+
 [[unpublished.wasmtime-wmemcheck]]
 version = "20.0.0"
 audited_as = "18.0.2"
@@ -831,6 +991,10 @@ audited_as = "21.0.1"
 
 [[unpublished.wasmtime-wmemcheck]]
 version = "24.0.0"
+audited_as = "22.0.0"
+
+[[unpublished.wasmtime-wmemcheck]]
+version = "24.0.1"
 audited_as = "22.0.0"
 
 [[unpublished.wiggle]]
@@ -853,6 +1017,10 @@ audited_as = "21.0.1"
 version = "24.0.0"
 audited_as = "22.0.0"
 
+[[unpublished.wiggle]]
+version = "24.0.1"
+audited_as = "22.0.0"
+
 [[unpublished.wiggle-generate]]
 version = "20.0.0"
 audited_as = "18.0.2"
@@ -873,6 +1041,10 @@ audited_as = "21.0.1"
 version = "24.0.0"
 audited_as = "22.0.0"
 
+[[unpublished.wiggle-generate]]
+version = "24.0.1"
+audited_as = "22.0.0"
+
 [[unpublished.wiggle-macro]]
 version = "20.0.0"
 audited_as = "18.0.2"
@@ -891,6 +1063,10 @@ audited_as = "21.0.1"
 
 [[unpublished.wiggle-macro]]
 version = "24.0.0"
+audited_as = "22.0.0"
+
+[[unpublished.wiggle-macro]]
+version = "24.0.1"
 audited_as = "22.0.0"
 
 [[unpublished.wiggle-test]]
@@ -915,6 +1091,10 @@ audited_as = "0.19.1"
 
 [[unpublished.winch-codegen]]
 version = "0.22.0"
+audited_as = "0.20.0"
+
+[[unpublished.winch-codegen]]
+version = "0.22.1"
 audited_as = "0.20.0"
 
 [[publisher.aho-corasick]]

--- a/winch/codegen/Cargo.toml
+++ b/winch/codegen/Cargo.toml
@@ -4,7 +4,7 @@ name = "winch-codegen"
 description = "Winch code generation library"
 license = "Apache-2.0 WITH LLVM-exception"
 repository = "https://github.com/bytecodealliance/wasmtime"
-version = "0.22.0"
+version = "0.22.1"
 edition.workspace = true
 
 [lints]


### PR DESCRIPTION
This is an [automated pull request][process] from CI to create a patch release for Wasmtime 24.0.1, requested by @juntyr.

It's recommended that maintainers double-check that [RELEASES.md] is up-to-date and that there are no known issues before merging this PR. When this PR is merged a release tag will automatically be created, crates will be published, and CI artifacts will be produced.

[RELEASES.md]: https://github.com/juntyr/wasmtime/blob/release-24.0.1/RELEASES.md
[process]: https://docs.wasmtime.dev/contributing-release-process.html
